### PR TITLE
code to add/remove 'active' class on refresh

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -123,9 +123,11 @@
 			$('option', this.select).each($.proxy(function(index, element) {
 				if ($(element).is(':selected')) {
 					$('ul li input[value="' + $(element).val() + '"]', this.container).prop('checked', true);
+					$('ul li input[value="' + $(element).val() + '"]', this.container).parents('li').addClass('active');
 				}
 				else {
 					$('ul li input[value="' + $(element).val() + '"]', this.container).prop('checked', false);
+					$('ul li input[value="' + $(element).val() + '"]', this.container).parents('li').removeClass('active');
 				}
 			}, this));
 			


### PR DESCRIPTION
Cool plugin!

I noticed that the 'active' class was not being applied or removed on the li's on refresh of the multi-select, so I wrote some code to remedy it!
