### PR TITLE
Add the ability for drop down menus to pull-right.

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ The used container holding both the dropdown button and the dropdown menu.
 		});
 	});
 
+**dropRight**
+
+Define if the menu should drop to the right of the button or not, by adding `pull-right` class to `<ul class="dropdown-menu">`. Default is false.
+
 **onChange**
 
 Assign an event handler to the change event:

--- a/index.html
+++ b/index.html
@@ -102,6 +102,8 @@
 					$('#example23').multiselect();
 					
 					$('#example24').multiselect();
+
+                                        $('#example25').multiselect({dropRight: true});
 				});
 			</script>
 			<p>
@@ -378,6 +380,24 @@
 						Specifiy an alternaitve label for the options: <code>&lt;option label=&quot;label&quot;&gt;&lt;/option&gt;</code>
 					</td>
 				</tr>
+                                <tr>
+                                        <td>
+						<div class="pull-left">
+                                                	<div class="btn-group">
+                                                        	<select id="example25" multiple="multiple">
+                                                                	<option value="analysis" label="Ana">Analysis</option>
+	                                                                <option value="algebra" label="LA">Linear Algebra</option>
+        	                                                        <option value="discrete" label="Discrete">Discrete Mathematics</option>
+                	                                                <option value="numerical" label="NumA">Numerical Analysis</option>
+                        	                                        <option value="probability" label="Proba">Probability Theory</option>
+                                	                        </select>
+                                        	        </div>
+						</div>
+                                        </td>
+                                        <td>
+                                                Make the menu drop right instead of dropping left with <code>dropRight</code>.
+                                        </td>
+                                </tr>
 			</table>
 			<div class="page-header">
 				<h1>Code</h1>

--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -61,7 +61,7 @@
 		
 		this.$container = $(this.options.buttonContainer)
 			.append('<button type="button" class="multiselect dropdown-toggle ' + this.options.buttonClass + '" data-toggle="dropdown">' + this.options.buttonText(this.getSelected(), this.$select) + '</button>')
-			.append('<ul class="dropdown-menu"></ul>');
+			.append('<ul class="dropdown-menu' + (this.options.dropRight ? ' pull-right' : '') + '"></ul>');
 
 		if (this.options.buttonWidth) {
 			$('button', this.$container).css({
@@ -113,6 +113,7 @@
 				
 			},
 			buttonClass: 'btn',
+                        dropRight: false,
 			selectedClass: 'active',
 			buttonWidth: 'auto',
 			buttonContainer: '<div class="btn-group" />',


### PR DESCRIPTION
Bootstrap dropdowns have the ability to drop up and drop right as well. While dropup is handled in bootstrap-multiselect by customizing `buttonContainer`, there is no capacity to add `.pull-right` to `.dropdown-menu`. This pull request adds that functionality via a `dropRight` option.

Why would I want to do that? To make this:
![capture](https://f.cloud.github.com/assets/48617/370131/a93ff746-a2e8-11e2-9ed9-d44b1fc4f13c.png)
