### PR TITLE
Fix single selection issue

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -208,11 +208,12 @@
 					$checkboxesNotThis.filter(function () { return $(this).is(':checked') != checked; }).trigger('click');
 				}
 				if (checked) {
-					//$option.attr('selected', 'selected');
 				    $option.prop('selected', true);
 
-				    if (!this.options.multiple)
-				    {
+				    if (this.options.multiple) {
+						$option.attr('selected', 'selected');
+				    }
+				    else {
 						if (this.options.selectedClass) {
 							$($checkboxesNotThis).parents('li').removeClass(this.options.selectedClass);
 						}


### PR DESCRIPTION
Apparently, setting the selected attribute on options breaks single selection selects on Chrome. Removed that, and we only set that for multiselects. Rely on the prop setting instead.

All other stuff works without the attribute set, even .val().
