### PR TITLE
Added support to override/extend default options

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -398,6 +398,8 @@
             }
         });
     };
+	 
+	$.fn.multiselect.Constructor = Multiselect;	 
 	
 	$(function() {
 		$("select[data-role=multiselect]").multiselect();


### PR DESCRIPTION
added a reference to the constructor so I can override the default options when initializing multiselect with data-role attribute
