### PR TITLE
Remove focus selection from input after user's click on it

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -310,6 +310,7 @@
 
 			$('.multiselect-container li a', this.$container).on('touchstart click', function (event) {
 				event.stopPropagation();
+				$(event.target).blur();
 			});
 
 			// Keyboard support.


### PR DESCRIPTION
When user clicks on input (result (check/uncheck) does not matter), it gets selection ![selection](https://f.cloud.github.com/assets/597016/628681/4bbf1cea-d0e3-11e2-8b42-be737cebdf4b.png).

 This looks a bit ugly. Especially when `selectedClass` is `null`. My change fixes that.
