### PR TITLE
Update bootstrap-multiselect.js

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -165,7 +165,7 @@
 			enableFiltering: false,
       enableCaseInsensitiveFiltering: false,
       filterPlaceholder: 'Search',
-			filterBehavior: 'text', // possible options: 'text', 'value', 'both'
+			filterBehavior: 'text' // possible options: 'text', 'value', 'both'
 		},
 
 		constructor: Multiselect,


### PR DESCRIPTION
Removed extra comma at the end of Multiselect.prototype, which breaks IE7.
