### PR TITLE
fix escape problem

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -94,7 +94,7 @@
                 else {
                     var selected = '';
                     options.each(function() {
-                        var label = ($(this).attr('label') !== undefined) ? $(this).attr('label') : $(this).text();
+                        var label = ($(this).attr('label') !== undefined) ? $(this).attr('label') : $(this).html();
 
                         selected += label + ', ';
                     });
@@ -133,7 +133,7 @@
             }
 
             // Support the label attribute on options.
-            var label = $(element).attr('label') || $(element).text();
+            var label = $(element).attr('label') || $(element).html();
             var value = $(element).val();
             var inputType = this.options.multiple ? "checkbox" : "radio";
 


### PR DESCRIPTION
With select option contains html escaped text, bootstrap-multiselect will unsecape it and write unescaped text directory.

Test case:
 http://hanzubon.jp/tmp/bootstrap-multiselect-test/escape_test.html

One of a select element contains `&lt;script&gt;alert('bbb')&lt;/script&gt;`

case 1:
 When read above page, alert box with text "bbb" will popup.

case 2:
 When select empty item (the select item contains above escaped text), alert box with text "bbb" will popup.
