### PR TITLE
Only show the filter if the number of options exceeds a set minimum.

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -66,7 +66,10 @@
 
         // Enable filtering.
         if (this.options.enableFiltering || this.options.enableCaseInsensitiveFiltering) {
-            this.buildFilter();
+            var enableFilterLength = Math.max(this.options.enableFiltering, this.options.enableCaseInsensitiveFiltering);
+            if (this.$select.find('option').length >= enableFilterLength) {
+                this.buildFilter();
+            }
         }
         
         // Build select all if enabled.


### PR DESCRIPTION
Not sure if this is this is the best approach, but this allows one to set either `enableFiltering` or `enableCaseInsensitiveFiltering` to an integer.  The filter will then only appear if the number of options >= the configured parameter value.  Similar to Select2's `minimumResultsForSearch` parameter.
