### PR TITLE
dataprovider option added

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -501,6 +501,17 @@
             }
         },
 
+        dataprovider: function(dataprovider) {
+            var optionDOM = "";
+
+            dataprovider.forEach(function (option) {
+                optionDOM += '<option value="' + option.value + '">' + option.label + '</option>';
+            });
+
+            this.$select.html(optionDOM);
+            this.rebuild();
+        },
+
         // Get options by merging defaults and given options.
         getOptions: function(options) {
             return $.extend({}, this.defaults, options);


### PR DESCRIPTION
This option will add nice functionality like this.

```
$("#multiselect").multiselect("dataprovider", 
                         [{label: "ACNP", value: "ACNP"}, {label: "test", value: "test"}]);
```

If you like to accept this PR, i can add functionality for `optgroup` as well.
