### PR TITLE
onChange callback context

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -39,6 +39,7 @@
         this.searchTimeout = null;
         
         this.options.multiple = this.$select.attr('multiple') == "multiple";
+        this.options.onChange = $.proxy(this.options.onChange, this);
         
         // Build select all if enabled.
         this.buildContainer();


### PR DESCRIPTION
this change makes onChange callback to be always called in current Multiselect instance context
this is usefull to have access to methods and properies of current Multileselect from onChange function with "this" keyword

for example

$('#myselect').multiselect({
  onChange(element, checked) {
    console.log(this.getSelected())
  }
});
