### PR TITLE
Update bootstrap-multiselect.js

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -18,6 +18,13 @@
                var config = ko.utils.unwrapObservable(valueAccessor());
                var selectOptions = allBindingsAccessor().options;
                var ms = $(element).data('multiselect');
+               
+               // If the ko.observableArray changes rebuild the multiselect
+               if (isObservableArray(selectOptions)) {
+                   selectOptions.subscribe(function (theArray) {
+                       $(element).multiselect('rebuild');
+                   });
+               }               
 
                if (!ms) {
                   $(element).multiselect(config);
@@ -31,6 +38,10 @@
             }
         };
     }
+    
+    function isObservableArray(obj) {
+        return ko.isObservable(obj) && !(obj.destroyAll === undefined);
+    };    
 
     /**
      * Constructor to create a new multiselect using the given select.


### PR DESCRIPTION
When using multiselect with Knockout to bind to an observableArray any changes to the array after the call to ko.applyBindings() are ignored. This patch rebuilds the mutliselect whenever a change is made to the ko.observableArray(). This is great for when a multiselect is loaded via a button click or dependent on other data such as choosing a state and then populating the multiselect with counties in that state.

The background for this fix can be seen here
https://github.com/davidstutz/bootstrap-multiselect/issues/214
