### PR TITLE
don't set buttonWidth if it's set to auto

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -209,7 +209,7 @@
             }
 
             // Manually add button width if set.
-            if (this.options.buttonWidth) {
+            if (this.options.buttonWidth && this.options.buttonWidth != 'auto') {
                 this.$button.css({
                     'width' : this.options.buttonWidth
                 });


### PR DESCRIPTION
setting width = auto on element will prevent the element from being
formatted via CSS
