### PR TITLE
Hotfix for a Chrome Mobile issue (fixes #178)

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -348,7 +348,13 @@
                 }
                 else {
                     // Unselect option.
-                    $option.prop('selected', false);
+                    // We do not use .prop() because of a chrome mobile issue
+                    var newValues = this.$select.val() || [];
+
+                    newValues.splice(newValues.indexOf($option.val()), 1);
+
+                    this.$select.val([]);
+                    this.$select.val(newValues);
                 }
 
                 this.$select.change();


### PR DESCRIPTION
I changed the .prop for another method to unselect element(s) of a dropdown so it also works on Chrome Mobile (issue #178).

The solution ain't pretty but that's all I found.
