### PR TITLE
Firefox Mobile issue when filter is on

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -553,7 +553,7 @@
 
                     this.$filter.val(this.query).on('click', function(event) {
                         event.stopPropagation();
-                    }).on('keydown', $.proxy(function(event) {
+                    }).on('input keydown', $.proxy(function(event) {
                         // This is useful to catch "keydown" events after the browser has updated the control.
                         clearTimeout(this.searchTimeout);
 


### PR DESCRIPTION
Firefox Mobile does not listen to key events when the keyboard with autocomplete suggestion is on, I added the input event to fix this issue.
