### PR TITLE
Fix deselect and select option when using options with empty values

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -104,6 +104,7 @@
         
         this.updateButtonText();
         this.updateSelectAll();
+        this.updateOptgroups();
         
         this.$select.hide().after(this.$container);
     };
@@ -195,6 +196,8 @@
             buttonTitleAttr: 'title',
             dropRight: false,
             selectedClass: 'active',
+            groupClass: 'multiselect-optgroup-item',
+            clickableGroups: false,
             buttonWidth: 'auto',
             buttonContainer: '<div class="btn-group" />',
             // Maximum height of the dropdown menu.
@@ -321,7 +324,8 @@
             // Bind the change event on the dropdown elements.
             $('li input', this.$ul).on('change', $.proxy(function(event) {
                 var checked = $(event.target).prop('checked') || false;
-                var isSelectAllOption = $(event.target).val() === this.options.selectAllValue;
+                var isSelectAllOption = $(event.target).val() === this.options.selectAllValue && this.$select[0][0].value === this.options.selectAllValue;
+                var optgroup = $(event.target).parents('label').attr('data-for');
 
                 // Apply or unapply the configured selected class.
                 if (this.options.selectedClass) {
@@ -342,35 +346,36 @@
                 var $optionsNotThis = $('option', this.$select).not($option);
                 var $checkboxesNotThis = $('input', this.$container).not($(event.target));
 
-                if (isSelectAllOption) {
-                    if (this.$select[0][0].value === this.options.selectAllValue) {
-                        var values = [];
+                if (isSelectAllOption || optgroup) {
+                    var values = [];
 
-                        var options = $('option[value!="' + this.options.selectAllValue + '"]', this.$select);
-                        for (var i = 0; i < options.length; i++) {
-                            // Additionally check whether the option is visible within the dropcown.
-                            if (options[i].value !== this.options.selectAllValue && this.getInputByValue(options[i].value).is(':visible')) {
-                                values.push(options[i].value);
-                            }
-                        }
+                    var $parent = this.$select;
+                    if (optgroup) {
+                        $parent = $parent.find("optgroup[label='" + optgroup + "']");
+                    }
 
-                        if (checked) {
-                            this.select(values);
+                    var options = $('option[value!="' + this.options.selectAllValue + '"]', $parent);
+                    for (var i = 0; i < options.length; i++) {
+                        // Additionally check whether the option is visible within the dropdown.
+                        if (options[i].value !== this.options.selectAllValue && this.getInputByValue(options[i].value).is(':visible')) {
+                            values.push(options[i].value);
                         }
-                        else {
-                            this.deselect(values);
-                        }
+                    }
+
+                    if (checked) {
+                        this.select(values);
+                    }
+                    else {
+                        this.deselect(values);
                     }
                 }
 
-                if (checked) {
-                    $option.prop('selected', true);
+                if ($option) {
+                    $option.prop('selected', checked);
+                    this.options.onChange($option, checked);
 
-                    if (this.options.multiple) {
-                        // Simply select additional option.
-                        $option.prop('selected', true);
-                    }
-                    else {
+                    if (!this.options.multiple && checked) {
+
                         // Unselect all other options and corresponding checkboxes.
                         if (this.options.selectedClass) {
                             $($checkboxesNotThis).parents('li').removeClass(this.options.selectedClass);
@@ -387,16 +392,12 @@
                         $optionsNotThis.parents("a").css("outline", "");
                     }
                 }
-                else {
-                    // Unselect option.
-                    $option.prop('selected', false);
-                }
 
                 this.$select.change();
-                this.options.onChange($option, checked);
                 
                 this.updateButtonText();
                 this.updateSelectAll();
+                this.updateOptgroups();
 
                 if(this.options.preventInputChangeEvent) {
                     return false;
@@ -532,6 +533,8 @@
                 $checkbox.parents('li')
                     .addClass(this.options.selectedClass);
             }
+
+            return $li;
         },
 
         /**
@@ -551,11 +554,16 @@
          */
         createOptgroup: function(group) {
             var groupName = $(group).prop('label');
+            var inputType = this.options.multiple ? "checkbox" : "radio";
 
             // Add a header for the group.
             var $li = $(this.templates.liGroup);
-            $('label', $li).text(groupName);
-
+            $('label', $li).addClass(inputType);
+            $('label', $li).text(groupName).attr('data-for', groupName);
+            if (this.options.multiple && this.options.clickableGroups) {
+                $('label', $li).prepend('<input type="' + inputType + '" /> ');
+                $li.wrapInner('<a>');
+            }
             this.$ul.append($li);
 
             if ($(group).is(':disabled')) {
@@ -564,12 +572,12 @@
 
             // Add the options of the group.
             $('option', group).each($.proxy(function(index, element) {
-                this.createOptionValue(element);
+                this.createOptionValue(element).addClass(this.options.groupClass);
             }, this));
         },
 
         /**
-         * Build the selct all.
+         * Build the select all.
          * Checks if a select all ahs already been created.
          */
         buildSelectAll: function() {
@@ -700,6 +708,7 @@
 
             this.updateButtonText();
             this.updateSelectAll();
+            this.updateOptgroups();
         },
 
         /**
@@ -799,6 +808,7 @@
             
             this.updateButtonText();
             this.updateSelectAll();
+            this.updateOptgroups();
         },
 
         /**
@@ -877,6 +887,21 @@
                 }
             }
         },
+
+        /**
+         * Updates the optgroup option based on the currently selected options.
+         */
+        updateOptgroups: function() {
+            if (this.options.multiple && this.options.clickableGroups) {
+                $('optgroup', this.$select).each($.proxy(function (key, optgroup) {
+                    var state = $('option', optgroup).length == $('option:selected', optgroup).length;
+
+                    $("label[data-for='" + $(optgroup).prop('label') + "'] > input", this.$container)
+                        .prop('checked', state)
+                        .parents('li').toggleClass(this.options.selectedClass, state);
+                }, this));
+            }
+        },
         
         /**
          * Update the button text and its title based on the currently selected options.
@@ -895,7 +920,7 @@
         /**
          * Get all selected options.
          * 
-         * @returns {jQUery}
+         * @returns {jQuery}
          */
         getSelected: function() {
             return $('option[value!="' + this.options.selectAllValue + '"]:selected', this.$select).filter(function() {


### PR DESCRIPTION
When using option elements with empty values (like for example, having a selectAllValue = '') the select and deselect option did not work properly. I removed both checks that prevented the empty string from becoming a list.
