### PR TITLE
Fix 'Select All' when there are dividers

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -800,7 +800,7 @@
             if (this.hasSelectAll()) {
                 var selected = this.getSelected();
                 
-                if (selected.length === $('option', this.$select).length - 1) {
+                if (selected.length === $('option:not([data-role=divider])', this.$select).length - 1) {
                     this.select(this.options.selectAllValue);
                 }
                 else {


### PR DESCRIPTION
There's a handy (although undocumented) feature in bootstrap-multiselect where you can create horizontal dividers if you have an `<option value="" data-role="divider"></option>`.

This, however was breaking the 'Select All' functionality since the divider option could never be "checked" in the UI.

You might also have the same issue with 'disabled' options - though I haven't confirmed that.
