### PR TITLE
includeSelectAllDivider option

### DIFF
--- a/index.html
+++ b/index.html
@@ -805,6 +805,24 @@
 						</td>
 					</tr>
 					<tr>
+						<td><code>includeSelectAllDivider</code></td>
+						<td>
+                            If set to <code>true</code> (along with <code>includeSelectAllOption</code>) a divider will be placed below the 'Select all' option.
+						</td>
+						<td>
+							<pre class="prettyprint linenums">
+&lt;script type=&quot;text/javascript&quot;&gt;
+  $(document).ready(function() {
+    $(&#39;.multiselect&#39;).multiselect({
+      includeSelectAllOption: true,
+      includeSelectAllDivider: true
+    });
+  });
+&lt;/script&gt;
+							</pre>
+						</td>
+					</tr>
+					<tr>
 						<td><code>selectAllText</code></td>
 						<td>
 							The label for the 'Select all' option.

--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -532,6 +532,9 @@
             
             // If options.includeSelectAllOption === true, add the include all checkbox.
             if (this.options.includeSelectAllOption && this.options.multiple && !alreadyHasSelectAll) {
+                if (this.options.includeSelectAllDivider) {
+                    this.$select.prepend('<option value="" disabled="disabled" data-role="divider">');
+                }
                 this.$select.prepend('<option value="' + this.options.selectAllValue + '">' + this.options.selectAllText + '</option>');
             }
         },


### PR DESCRIPTION
Add an optional `includeSelectAllDivider` option to add a "divider" immediately after the "select all" option

![screen shot 2014-03-04 at 12 00 20 pm](https://f.cloud.github.com/assets/97612/2325725/6950fea8-a3d9-11e3-8c83-3f9626ade75f.png)
