### PR TITLE
Fixed the error "Cannot read property 'is' of undefined " when applying ...

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -347,7 +347,7 @@
                         var options = $('option[value!="' + this.options.selectAllValue + '"]', this.$select);
                         for (var i = 0; i < options.length; i++) {
                             // Additionally check whether the option is visible within the dropcown.
-                            if (options[i].value !== this.options.selectAllValue && this.getInputByValue(options[i].value).is(':visible')) {
+                            if (options[i].value !== this.options.selectAllValue && this.getInputByValue(options[i].value) && this.getInputByValue(options[i].value).is(':visible')) {
                                 values.push(options[i].value);
                             }
                         }


### PR DESCRIPTION
Fixed the error "Cannot read property 'is' of undefined " when applying "includeSelectAllOption" and "includeSelectAllDivider" options
