### PR TITLE
default includeSelectAllDivider, switch to div

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -203,6 +203,7 @@
             includeSelectAllIfMoreThan: 0,
             selectAllText: ' Select all',
             selectAllValue: 'multiselect-all',
+            includeSelectAllDivider: false,
             enableFiltering: false,
             enableCaseInsensitiveFiltering: false,
             filterPlaceholder: 'Search',
@@ -219,7 +220,7 @@
             ul: '<ul class="multiselect-container dropdown-menu"></ul>',
             filter: '<div class="input-group"><span class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span><input class="form-control multiselect-search" type="text"></div>',
             li: '<li><a href="javascript:void(0);"><label></label></a></li>',
-            divider: '<li class="divider"></li>',
+            divider: '<div class="divider"></div>',
             liGroup: '<li><label class="multiselect-group"></label></li>'
         },
 


### PR DESCRIPTION
There isnt a need to have divider be an li. If it is you have to add a bunch of mods on existing jQuery selectors, in order not to catch that one. Make it a div, it looks the same, and doesnt break other features
