### PR TITLE
Option groups support for the dataprovider method

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -815,10 +815,23 @@
          */
         dataprovider: function(dataprovider) {
             var optionDOM = "";
-            dataprovider.forEach(function (option) {
-                optionDOM += '<option value="' + option.value + '">' + option.label + '</option>';
-            });
+            var groupCounter = 0;
 
+            dataprovider.forEach(function (option) {
+                if ($.isArray(option.children)) {
+                    groupCounter++;
+                    optionDOM += '<optgroup label="' + (option.title || 'Group ' + groupCounter) + '">';
+
+                    option.children.forEach(function(subOption) {
+                        optionDOM += '<option value="' + subOption.value + '">' + (subOption.label || subOption.value) + '</option>';
+                    });
+
+                    optionDOM += '</optgroup>';
+                } else {
+                    optionDOM += '<option value="' + option.value + '">' + (option.label || option.value) + '</option>';
+                }
+            });
+            
             this.$select.html(optionDOM);
             this.rebuild();
         },


### PR DESCRIPTION
Use the same format as Select2 : [{children: array (of options), [title: string]}]

Additionally :
- if no title is given, use the generic "Group n", with n as group index.
- for options if no label is given, use value as label
