### PR TITLE
Moving down the onChange callback

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -391,10 +391,11 @@
                 }
 
                 this.$select.change();
-                this.options.onChange($option, checked);
-                
+
                 this.updateButtonText();
                 this.updateSelectAll();
+                
+                this.options.onChange($option, checked);
 
                 if(this.options.preventInputChangeEvent) {
                     return false;


### PR DESCRIPTION
Moving down the onChange callback after this.updateSelectAll() allows to access the correct selected values during the callback.
