### PR TITLE
Adding missing `nonSelectedText` option to documentation.

### DIFF
--- a/index-2-3.html
+++ b/index-2-3.html
@@ -642,6 +642,21 @@
 							</pre>
 						</td>
 					</tr>
+					<tr>
+						<td><code>nonSelectedText</code></td>
+						<td>A string that is displayed when no options are selected.</td>
+						<td>
+							<pre class="prettyprint linenums">
+&lt;script type=&quot;text/javascript&quot;&gt;
+  $(document).ready(function() {
+    $(&#39;.multiselect&#39;).multiselect({
+      nonSelectedText: 'You have not selected any options'
+    });
+  });
+&lt;/script&gt;
+							</pre>
+						</td>
+					</tr>					
                     <tr>
 						<td><code>buttonTitle</code></td>
 						<td>Function defining the title of the button. Similar to the <code>buttonText</code> option.</td>

--- a/index.html
+++ b/index.html
@@ -667,6 +667,21 @@
 							</pre>
 						</td>
 					</tr>
+					<tr>
+						<td><code>nonSelectedText</code></td>
+						<td>A string that is displayed when no options are selected.</td>
+						<td>
+							<pre class="prettyprint linenums">
+&lt;script type=&quot;text/javascript&quot;&gt;
+  $(document).ready(function() {
+    $(&#39;.multiselect&#39;).multiselect({
+      nonSelectedText: 'You have not selected any options'
+    });
+  });
+&lt;/script&gt;
+							</pre>
+						</td>
+					</tr>
                     <tr>
 						<td><code>buttonTitle</code></td>
 						<td>Function defining the title of the button. Similar to the <code>buttonText</code> option.</td>


### PR DESCRIPTION
- Adding the `nonSelectedText` option and description to both the Bootstrap 3 and 2 multiselect documentation.
