### PR TITLE
adding namespace to fix keydown event

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -440,7 +440,7 @@
             });
 
             // Keyboard support.
-            this.$container.on('keydown', $.proxy(function(event) {
+            this.$container.off('keydown.multiselect').on('keydown.multiselect', $.proxy(function(event) {
                 if ($('input[type="text"]', this.$container).is(':focus')) {
                     return;
                 }


### PR DESCRIPTION
When using keyboard navigation feature, after calling rebuild or dataprovider method, this would skip the number of rows per time the method was called.

Here is a JSFiddle showing the problem: http://jsfiddle.net/wyze/28zq2/
