### PR TITLE
prevent the "select all" from being created twice

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -310,6 +310,9 @@
                 var tag = $(element).prop('tagName')
                     .toLowerCase();
 
+                if ($(element).prop('value') == this.options.selectAllValue)
+                    return
+
                 if (tag === 'optgroup') {
                     this.createOptgroup(element);
                 }


### PR DESCRIPTION
in my form (auto generated by django) I create a filed multiselect-all, in order to know when all is selected and make filtering easier on the DB.
latest version (from HEAD) creates a duplicate "select all" options.
this code prevent the duplicate from being created.
