### PR TITLE
Knockout.js Binding: Fixing the initialization of the selected items in the multi-select

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -30,6 +30,8 @@
                 $(element).multiselect(config);
 
                 if (isObservableArray(listOfSelectedItems)) {
+                   //set the initial selection state on the multi-select list
+                    $(element).multiselect('select', ko.utils.unwrapObservable(listOfSelectedItems));
                     // Subscribe to the selectedOptions: ko.observableArray
                     listOfSelectedItems.subscribe(function (changes) {
                         var addedArray = [], deletedArray = [];


### PR DESCRIPTION
Fixing the initialization of the selected items in the multi-select for Knockout.js binding integration.  Currently a persisted binding value isn't being initialized correctly when using KO.  Instead the selectedOptions are only being set on during the update binding function or when the observableArray is changed.  With this fix, if the observableArray has initial values, they are selected as necessary.s
