### PR TITLE
Only deploy the necessary files with Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,5 +8,15 @@
   "dependencies": {
     "jquery": ">= 1.11.0",
     "bootstrap": ">= 2.3.2"
-  }
+  },
+  "ignore": [
+    "js/bootstrap-3*",
+    "js/jquery*",
+    "js/prettify*",
+    "css/bootstrap-3*",
+    "css/prettify*",
+    "*.html",
+    "*.git*",
+    "fonts"
+  ]
 }


### PR DESCRIPTION
The only deployed files from bower will be:

```
bower_components\bootstrap-multiselect
│   .bower.json
│   bower.json
│   README.md
│
├───css
│       bootstrap-multiselect.css
│
├───js
│       bootstrap-multiselect.js
│
└───less
        bootstrap-multiselect.less
```
