### PR TITLE
Created an inheritClasses option (default: false) that pulls classes

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -238,6 +238,7 @@
             // If maximum height is exceeded a scrollbar will be displayed.
             maxHeight: false,
             checkboxName: false,
+            inheritClasses: false,
             includeSelectAllOption: false,
             includeSelectAllIfMoreThan: 0,
             selectAllText: ' Select all',
@@ -285,7 +286,9 @@
          */
         buildButton: function() {
             this.$button = $(this.options.templates.button).addClass(this.options.buttonClass);
-
+            if (this.$select.attr('class') && this.options.inheritClasses) {
+                this.$button.addClass(this.$select.attr('class'));
+            }
             // Adopt active state.
             if (this.$select.prop('disabled')) {
                 this.disable();


### PR DESCRIPTION
I needed a way to designate classes that will be added to the target button created, so this will pull the classes from the original select.  It defaults to false as to not affect current implementations.