### PR TITLE
** Fix for #431 **

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -261,7 +261,7 @@
                 ul: '<ul class="multiselect-container dropdown-menu"></ul>',
                 filter: '<li class="multiselect-item filter"><div class="input-group"><span class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span><input class="form-control multiselect-search" type="text"></div></li>',
                 filterClearBtn: '<span class="input-group-btn"><button class="btn btn-default multiselect-clear-filter" type="button"><i class="glyphicon glyphicon-remove-circle"></i></button></span>',
-                li: '<li><a href="javascript:void(0);"><label></label></a></li>',
+                li: '<li><a tabindex="0"><label></label></a></li>',
                 divider: '<li class="multiselect-item divider"></li>',
                 liGroup: '<li class="multiselect-item multiselect-group"><label></label></li>'
             }
@@ -451,19 +451,24 @@
                 }
             }, this));
 
+            $('li a', this.$ul).on('mousedown', function(e) {
+                if (e.shiftKey) {
+                    // Prevent selecting text by Shift+click
+                    return false;
+                }
+            });
+
             $('li a', this.$ul).on('touchstart click', function(event) {
                 event.stopPropagation();
 
                 var $target = $(event.target);
-
-                if (document.getSelection().type === 'Range') {
-                  var $input = $(this).find("input:first");
-
-                  $input.prop("checked", !$input.prop("checked"))
-                      .trigger("change");
-                }
-
+                
                 if (event.shiftKey) {
+                    if($target.is("label")){ // Handles checkbox selection manually (see https://github.com/davidstutz/bootstrap-multiselect/issues/431)
+                        event.preventDefault();
+                        $target = $(this).find("input");
+                        $target.prop("checked", !$target.prop("checked")).trigger("change");
+                    }
                     var checked = $target.prop('checked') || false;
 
                     if (checked) {

--- a/tests/spec/bootstrap-multiselect.js
+++ b/tests/spec/bootstrap-multiselect.js
@@ -596,7 +596,7 @@ describe('Bootstrap Multiselect Specific Issues', function() {
         selection.addRange(range);
 
         if (document.getSelection().type === 'Range') {
-            $('#multiselect-container').find('a:first').trigger('click');
+            $('#multiselect-container').find('a:first label').trigger('click');
             expect($('#multiselect-container').find('input:first').prop('checked')).toBe(true);
         }
 


### PR DESCRIPTION
IMPORTANT: This pull request only fixes the problem #431. 
I've submitted #439 that is based on this commit but also includes performance improvements for the shift+click range selection. I'll leave which one you want to merge at your discretion, just reject the other one.

-> See https://bugzilla.mozilla.org/show_bug.cgi?id=559506
-> Removed the javascript:void(0) href for anchor elements in the multiselect dropdown
-> Added a tabindex = 0 to keep the anchors focus-able
-> Added code to remove any text selection when using shift+click
-> Handles the checkbox selection manually when done using shift+click on its label