### PR TITLE
Shift + Click range selection improvements

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -261,7 +261,7 @@
                 ul: '<ul class="multiselect-container dropdown-menu"></ul>',
                 filter: '<li class="multiselect-item filter"><div class="input-group"><span class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span><input class="form-control multiselect-search" type="text"></div></li>',
                 filterClearBtn: '<span class="input-group-btn"><button class="btn btn-default multiselect-clear-filter" type="button"><i class="glyphicon glyphicon-remove-circle"></i></button></span>',
-                li: '<li><a href="javascript:void(0);"><label></label></a></li>',
+                li: '<li><a tabindex="0"><label></label></a></li>',
                 divider: '<li class="multiselect-item divider"></li>',
                 liGroup: '<li class="multiselect-item multiselect-group"><label></label></li>'
             }
@@ -451,19 +451,24 @@
                 }
             }, this));
 
+            $('li a', this.$ul).on('mousedown', function(e) {
+                if (e.shiftKey) {
+                    // Prevent selecting text by Shift+click
+                    return false;
+                }
+            });
+
             $('li a', this.$ul).on('touchstart click', function(event) {
                 event.stopPropagation();
 
                 var $target = $(event.target);
-
-                if (document.getSelection().type === 'Range') {
-                  var $input = $(this).find("input:first");
-
-                  $input.prop("checked", !$input.prop("checked"))
-                      .trigger("change");
-                }
-
+                
                 if (event.shiftKey) {
+                    if($target.is("label")){ // Handles checkbox selection manually (see https://github.com/davidstutz/bootstrap-multiselect/issues/431)
+                        event.preventDefault();
+                        $target = $(this).find("input");
+                        $target.prop("checked", !$target.prop("checked")).trigger("change");
+                    }
                     var checked = $target.prop('checked') || false;
 
                     if (checked) {

--- a/tests/spec/bootstrap-multiselect.js
+++ b/tests/spec/bootstrap-multiselect.js
@@ -596,7 +596,7 @@ describe('Bootstrap Multiselect Specific Issues', function() {
         selection.addRange(range);
 
         if (document.getSelection().type === 'Range') {
-            $('#multiselect-container').find('a:first').trigger('click');
+            $('#multiselect-container').find('a:first label').trigger('click');
             expect($('#multiselect-container').find('input:first').prop('checked')).toBe(true);
         }
 


### PR DESCRIPTION
IMPORTANT: Based on the code in the pull request #435.

Changes:

-> Now able to select/deselect ranges
-> The range is based on the previously active checkbox. (i.e: the user clicks a checkbox no 1 then checkbox no 5. The interval will be [1,5].)
-> The range new state (selected or deselected) depends on the last option clicked new value. Example: If the checkbox is Shift-clicked and becomes selected, the whole range will be too.
-> Improved the range select speed tremendously by only notifying the select for the "change" event once the whole range finished changing and manually doing the selection or deselection.