### PR TITLE
** fix for #437 **

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -183,7 +183,7 @@
              * @param {jQuery} element
              * @returns {String}
              */
-            label: function(element){
+            getLabel: function(element){
                 return $(element).attr('label') || $(element).html();
             },
             /**
@@ -574,7 +574,7 @@
             }
 
             // Support the label attribute on options.
-            var label = this.options.label(element);
+            var label = this.options.getLabel(element);
             var value = $element.val();
             var inputType = this.options.multiple ? "checkbox" : "radio";
 


### PR DESCRIPTION
-> Fixed a bug when the data-label attribute is used on the original select. It was conflicting with the custom function called "label(element)" and overriding it.
Renamed label() to getLabel()