### PR TITLE
Improved knockout binding

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -19,51 +19,57 @@
 
                 $element.multiselect(config);
 
-                var options = allBindings.get('options');
-                if (ko.isObservable(options)) {
-                    ko.computed({
-                        read: function() {
-                            options();
-                            setTimeout(function() {
-                                var ms = $element.data('multiselect');
-                                if (ms)
-                                    ms.updateOriginalOptions();//Not sure how beneficial this is.
-                                $element.multiselect('rebuild');
-                            }, 1);
-                        },
-                        disposeWhenNodeIsRemoved: element
-                    });
+                if (allBindings.has('options')) {
+                    var options = allBindings.get('options');
+                    if (ko.isObservable(options)) {
+                        ko.computed({
+                            read: function() {
+                                options();
+                                setTimeout(function() {
+                                    var ms = $element.data('multiselect');
+                                    if (ms)
+                                        ms.updateOriginalOptions();//Not sure how beneficial this is.
+                                    $element.multiselect('rebuild');
+                                }, 1);
+                            },
+                            disposeWhenNodeIsRemoved: element
+                        });
+                    }
                 }
 
                 //value and selectedOptions are two-way, so these will be triggered even by our own actions.
                 //It needs some way to tell if they are triggered because of us or because of outside change.
                 //It doesn't loop but it's a waste of processing.
-                var value = allBindings.get('value');
-                if (ko.isObservable(value)) {
-                    ko.computed({
-                        read: function() {
-                            value();
-                            setTimeout(function() {
-                                $element.multiselect('refresh');
-                            }, 1);
-                        },
-                        disposeWhenNodeIsRemoved: element
-                    }).extend({ rateLimit: 100, notifyWhenChangesStop: true });
+                if (allBindings.has('value')) {
+                    var value = allBindings.get('value');
+                    if (ko.isObservable(value)) {
+                        ko.computed({
+                            read: function() {
+                                value();
+                                setTimeout(function() {
+                                    $element.multiselect('refresh');
+                                }, 1);
+                            },
+                            disposeWhenNodeIsRemoved: element
+                        }).extend({ rateLimit: 100, notifyWhenChangesStop: true });
+                    }
                 }
 
                 //Switched from arrayChange subscription to general subscription using 'refresh'.
                 //Not sure performance is any better using 'select' and 'deselect'.
-                var selectedOptions = allBindings.get('selectedOptions');
-                if (ko.isObservable(selectedOptions)) {
-                    ko.computed({
-                        read: function() {
-                            selectedOptions();
-                            setTimeout(function() {
-                                $element.multiselect('refresh');
-                            }, 1);
-                        },
-                        disposeWhenNodeIsRemoved: element
-                    }).extend({ rateLimit: 100, notifyWhenChangesStop: true });
+                if (allBindings.has('selectedOptions')) {
+                    var selectedOptions = allBindings.get('selectedOptions');
+                    if (ko.isObservable(selectedOptions)) {
+                        ko.computed({
+                            read: function() {
+                                selectedOptions();
+                                setTimeout(function() {
+                                    $element.multiselect('refresh');
+                                }, 1);
+                            },
+                            disposeWhenNodeIsRemoved: element
+                        }).extend({ rateLimit: 100, notifyWhenChangesStop: true });
+                    }
                 }
 
                 ko.utils.domNodeDisposal.addDisposeCallback(element, function() {

--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -13,7 +13,7 @@
         ko.bindingHandlers.multiselect = {
             after: ['options', 'value', 'selectedOptions'],
 
-            init: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
+            init: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
                 var $element = $(element);
                 var config = ko.toJS(valueAccessor());
 
@@ -21,14 +21,17 @@
 
                 var options = allBindings.get('options');
                 if (ko.isObservable(options)) {
-                    ko.computed(function () {
-                        options();
-                        setTimeout(function () {
-                            var ms = $element.data('multiselect');
-                            if (ms)
-                                ms.updateOriginalOptions();//Not sure how beneficial this is.
-                            $element.multiselect('rebuild');
-                        }, 1);
+                    ko.computed({
+                        read: function() {
+                            options();
+                            setTimeout(function() {
+                                var ms = $element.data('multiselect');
+                                if (ms)
+                                    ms.updateOriginalOptions();//Not sure how beneficial this is.
+                                $element.multiselect('rebuild');
+                            }, 1);
+                        },
+                        disposeWhenNodeIsRemoved: element
                     });
                 }
 
@@ -37,32 +40,38 @@
                 //It doesn't loop but it's a waste of processing.
                 var value = allBindings.get('value');
                 if (ko.isObservable(value)) {
-                    ko.computed(function () {
-                        value();
-                        setTimeout(function () { 
-                            $element.multiselect('refresh');
-                        }, 1);
-                    }).extend( { rateLimit: 100, notifyWhenChangesStop: true });
+                    ko.computed({
+                        read: function() {
+                            value();
+                            setTimeout(function() {
+                                $element.multiselect('refresh');
+                            }, 1);
+                        },
+                        disposeWhenNodeIsRemoved: element
+                    }).extend({ rateLimit: 100, notifyWhenChangesStop: true });
                 }
 
                 //Switched from arrayChange subscription to general subscription using 'refresh'.
                 //Not sure performance is any better using 'select' and 'deselect'.
                 var selectedOptions = allBindings.get('selectedOptions');
                 if (ko.isObservable(selectedOptions)) {
-                    ko.computed(function () {
-                        selectedOptions();
-                        setTimeout(function () {
-                            $element.multiselect('refresh');
-                        }, 1);
+                    ko.computed({
+                        read: function() {
+                            selectedOptions();
+                            setTimeout(function() {
+                                $element.multiselect('refresh');
+                            }, 1);
+                        },
+                        disposeWhenNodeIsRemoved: element
                     }).extend({ rateLimit: 100, notifyWhenChangesStop: true });
                 }
 
-                ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
+                ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
                     $element.multiselect('destroy');
                 });
             },
 
-            update: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
+            update: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
                 var $element = $(element);
                 var config = ko.toJS(valueAccessor());
 

--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -11,69 +11,65 @@
 
     if (typeof ko !== 'undefined' && ko.bindingHandlers && !ko.bindingHandlers.multiselect) {
         ko.bindingHandlers.multiselect = {
+            after: ['options', 'value', 'selectedOptions'],
 
-            init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+            init: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
+                var $element = $(element);
+                var config = ko.toJS(valueAccessor());
 
-                var listOfSelectedItems = allBindingsAccessor().selectedOptions;
-                var config = ko.utils.unwrapObservable(valueAccessor());
+                $element.multiselect(config);
 
-                $(element).multiselect(config);
-
-                if (isObservableArray(listOfSelectedItems)) {
-                    
-                    // Set the initial selection state on the multiselect list.
-                    $(element).multiselect('select', ko.utils.unwrapObservable(listOfSelectedItems));
-                    
-                    // Subscribe to the selectedOptions: ko.observableArray
-                    listOfSelectedItems.subscribe(function (changes) {
-                        var addedArray = [], deletedArray = [];
-                        forEach(changes, function (change) {
-                            switch (change.status) {
-                                case 'added':
-                                    addedArray.push(change.value);
-                                    break;
-                                case 'deleted':
-                                    deletedArray.push(change.value);
-                                    break;
-                            }
-                        });
-                        
-                        if (addedArray.length > 0) {
-                            $(element).multiselect('select', addedArray);
-                        }
-                        
-                        if (deletedArray.length > 0) {
-                            $(element).multiselect('deselect', deletedArray);
-                        }
-                    }, null, "arrayChange");
-                }
-            },
-
-            update: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-
-                var listOfItems = allBindingsAccessor().options,
-                    ms = $(element).data('multiselect'),
-                    config = ko.utils.unwrapObservable(valueAccessor());
-
-                if (isObservableArray(listOfItems)) {
-                    // Subscribe to the options: ko.observableArray incase it changes later
-                    listOfItems.subscribe(function (theArray) {
-                        $(element).multiselect('rebuild');
+                var options = allBindings.get('options');
+                if (ko.isObservable(options)) {
+                    ko.computed(function () {
+                        options();
+                        setTimeout(function () {
+                            var ms = $element.data('multiselect');
+                            if (ms)
+                                ms.updateOriginalOptions();//Not sure how beneficial this is.
+                            $element.multiselect('rebuild');
+                        }, 1);
                     });
                 }
 
-                if (!ms) {
-                    $(element).multiselect(config);
+                //value and selectedOptions are two-way, so these will be triggered even by our own actions.
+                //It needs some way to tell if they are triggered because of us or because of outside change.
+                //It doesn't loop but it's a waste of processing.
+                var value = allBindings.get('value');
+                if (ko.isObservable(value)) {
+                    ko.computed(function () {
+                        value();
+                        setTimeout(function () { 
+                            $element.multiselect('refresh');
+                        }, 1);
+                    }).extend( { rateLimit: 100, notifyWhenChangesStop: true });
                 }
-                else {
-                    ms.updateOriginalOptions();
+
+                //Switched from arrayChange subscription to general subscription using 'refresh'.
+                //Not sure performance is any better using 'select' and 'deselect'.
+                var selectedOptions = allBindings.get('selectedOptions');
+                if (ko.isObservable(selectedOptions)) {
+                    ko.computed(function () {
+                        selectedOptions();
+                        setTimeout(function () {
+                            $element.multiselect('refresh');
+                        }, 1);
+                    }).extend({ rateLimit: 100, notifyWhenChangesStop: true });
                 }
+
+                ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
+                    $element.multiselect('destroy');
+                });
+            },
+
+            update: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
+                var $element = $(element);
+                var config = ko.toJS(valueAccessor());
+
+                $element.multiselect('setOptions', config);
+                $element.multiselect('rebuild');
             }
         };
-    }
-
-    function isObservableArray(obj) {
-        return ko.isObservable(obj) && !(obj.destroyAll === undefined);
     }
 
     function forEach(array, callback) {


### PR DESCRIPTION
Improves the initialization of the multiselect by waiting for other select related bindings to finish first.
Moved the subscription to other binder events to init so they aren't re-executed all the time.
Added support for value binding.
Added support for observable configuration properties.
Observable subscription rate-limited (by @IDisposable).
Simplified how selection changes are processed (simpler code, not sure about performance).