### PR TITLE
Change dataprovider tags variable into an array

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1067,7 +1067,7 @@
         dataprovider: function(dataprovider) {
             var optionDOM = "";
             var groupCounter = 0;
-            var tags = $(''); // create empty jQuery array
+            var tags = []; // create empty array
 
             $.each(dataprovider, function (index, option) {
                 var tag;
@@ -1094,9 +1094,10 @@
                         title: option.title,
                         selected: !!option.selected
                     });
+                    
+                    tags.push(tag);
                 }
 
-                tags = tags.add(tag);
             });
             
             this.$select.empty().append(tags);


### PR DESCRIPTION
Change dataprovider tags variable into an array instead of jquery object to keep order of dataprovider array. Got rid of .add() as jquery states:

http://api.jquery.com/add/
"Do not assume that this method appends the elements to the existing collection in the order they are passed to the .add() method"