### PR TITLE
Fix error once you click select all

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -435,7 +435,7 @@
                     }
                     else {
                         // Unselect option.
-                        $option.prop('selected', false);
+                        if($option && typeof $option.prop === 'function') $option.prop('selected', false);
                     }
                 }
 


### PR DESCRIPTION
Once you click select all you can get an error which tell us $option is undefined.