### PR TITLE
Ignore moved entries

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "bootstrap-multiselect",
   "description": "Twitter Bootstrap plugin to make selects user friendly.",
   "homepage": "http://davidstutz.github.io/bootstrap-multiselect/",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "keywords": [
       "js",
       "css",

--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -28,6 +28,9 @@
                     listOfSelectedItems.subscribe(function (changes) {
                         var addedArray = [], deletedArray = [];
                         forEach(changes, function (change) {
+                            if(typeof (change.moved) !== 'undefined') {
+                                return;
+                            }
                             switch (change.status) {
                                 case 'added':
                                     addedArray.push(change.value);


### PR DESCRIPTION
If the selectedOptions aren't sorted then Knockout sorts them on each change by adding and removing entries. When doing so it includes the moved property with the new index if for the deleted change, and the old index for the added change. And since the selectedOptions contains just pure values, while the options can contain objects where you select optionsName and optionsValue. This behavior means that Knockout will sort the selected items on each change if you sort you options by optionsName and your selectedOptions by something else were ever they are stored. Giving a very strange and unwanted behavior if the multiselect is prepopulated with selected values.

Because these changes are not ignored by the binding, and deletions happen after adding each moved items is removed from the multiselect (but not the underlying selectedOptions).

The fix to this is to simply ignore the changes, as suggested by @Tyf0x 

This fixes davidstutz/bootstrap-multiselect#424 and also fixes davidstutz/bootstrap-multiselect#327 