### PR TITLE
Set to enabled on rebuild when options is not empty and disableIfEmpty i...

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1153,6 +1153,9 @@
             if (this.options.disableIfEmpty && $('option', this.$select).length <= 0) {
                 this.disable();
             }
+            else {
+                this.enable();
+            }
             
             if (this.options.dropRight) {
                 this.$ul.addClass('pull-right');


### PR DESCRIPTION
When rebuild the multiselect set it to enabled if it contains data.
See issue: https://github.com/davidstutz/bootstrap-multiselect/issues/494