### PR TITLE
Fixed "All Selected" problem on non-multiselect with one option

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -197,7 +197,11 @@
                 if (options.length === 0) {
                     return this.nonSelectedText;
                 }
-                else if (this.allSelectedText && options.length == $('option', $(select)).length) {
+                else if (this.allSelectedText 
+                            && options.length === $('option', $(select)).length 
+                            && $('option', $(select)).length !== 1 
+                            && this.multiple) {
+
                     if (this.selectAllNumber) {
                         return this.allSelectedText + ' (' + options.length + ')';
                     }


### PR DESCRIPTION
There’s some situation when there are only one option and that displays
“All selected” which is only correct if the select tag is “multiple”.
In using this plugin for “single” dropdowns as well, there are
situations when there’s only one option and it shouldn’t show “All
selected”. This fixes that.  

The problem:
![screenshot 2015-03-13 01 06 12](https://cloud.githubusercontent.com/assets/4754005/6634953/388e46da-c91d-11e4-998e-606a9029fc3d.png)

The fix:
![screenshot 2015-03-13 01 07 43](https://cloud.githubusercontent.com/assets/4754005/6634974/65605d6a-c91d-11e4-864e-79bd888f1482.png)


