### PR TITLE
Add a placeholder using data-placeholder attribute

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -138,6 +138,11 @@
     function Multiselect(select, options) {
 
         this.$select = $(select);
+        
+        // Placeholder via data attributes
+        if (this.$select.attr("data-placeholder"))
+            options.nonSelectedText = this.$select.data("placeholder");
+        
         this.options = this.mergeOptions($.extend({}, options, this.$select.data()));
 
         // Initialization.


### PR DESCRIPTION
Add a placeholder using data-placeholder attribute so we don't need to create an entire function if we want to add placeholders to multiple multiselects.

It is currently not possible to add a placeholder based on the select.