### PR TITLE
added delimiter option to control the delimiter character for mouse-over

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -223,8 +223,9 @@
                 }
                 else {
                     var selected = '';
+                    var delimiter = this.delimiter;
                     options.each(function () {
-                        selected += $(this).text() + ', ';
+                        selected += $(this).text() + delimiter;
                     });
                     return selected.substr(0, selected.length - 2);
                 }
@@ -317,6 +318,7 @@
             allSelectedText: 'All selected',
             numberDisplayed: 3,
             disableIfEmpty: false,
+            delimiter: ', ',
             templates: {
                 button: '<button type="button" class="multiselect dropdown-toggle" data-toggle="dropdown"><span class="multiselect-selected-text"></span> <b class="caret"></b></button>',
                 ul: '<ul class="multiselect-container dropdown-menu"></ul>',

--- a/index.html
+++ b/index.html
@@ -454,6 +454,37 @@
                                 </td>
                             </tr>
                             <tr>
+                                <td><code>delimiter</code></td>
+                                <td>
+                                    <p>
+                                        Sets the separator for the list of selected items for mouse-over. Defaults to ', '. Set to '\n' for a neater display.
+                                    </p>
+
+                                    <div class="example">
+                                        <script type="text/javascript">
+                                            $(document).ready(function() {
+                                                $('#example-delimiter').multiselect({
+                                                    delimiter: '\n'
+                                                });
+                                            });
+                                        </script>
+                                        <select id="example-delimiter" multiple="multiple"></select>
+                                    </div>
+                                    <div class="highlight">
+<pre class="prettyprint linenums">
+&lt;script type=&quot;text/javascript&quot;&gt;
+    $(document).ready(function() {
+        $('#example-delimiter').multiselect({
+            delimiter: '\n' 
+        });
+    });
+&lt;/script&gt;
+</pre>
+                                    </div>
+                                </td>
+                            </tr>
+
+                            <tr>
                                 <td><code>disableIfEmpty</code></td>
                                 <td>
                                     <p>


### PR DESCRIPTION
Dear David,

I love your multiselect plugin. It has now replaced select2 and jquery.multiselect in our product. Thank you for creating such a well-designed and documented software.

I have simply added a 'delimiter' option for specifying the character for separating the various selected items upon mouse-over.

I have also updated the index.html file to reflect this change.

Do give this option some consideration.