### PR TITLE
Added text() for <option/> created from a dataprovider

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1223,6 +1223,7 @@
                         selected: !!option.selected,
                         disabled: !!option.disabled
                     });
+                    $tag.text(option.label || option.value);
                 }
                 
                 $select.append($tag);


### PR DESCRIPTION
I want to resolve #547 by adding .text() to the </option> generated by a dataprovider. Fixes mouseover text appearing blank for multiselects generated by dataprovider.