### PR TITLE
Added package.json for NPM publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "bootstrap-multiselect",
+  "version": "0.9.13-1",
+  "description": "JQuery multiselect plugin based on Twitter Bootstrap.",
+  "main": "dist/js/bootstrap-multiselect.js",
+  "directories": {
+    "doc": "docs",
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/davidstutz/bootstrap-multiselect"
+  },
+  "keywords": [
+    "js",
+    "css",
+    "less",
+    "bootstrap",
+    "jquery",
+    "multiselect"
+  ],
+  "author": "David Stutz",
+  "license": "Apache License, Version 2.0",
+  "bugs": {
+    "url": "https://github.com/davidstutz/bootstrap-multiselect/issues"
+  },
+  "homepage": "https://github.com/davidstutz/bootstrap-multiselect"
+}


### PR DESCRIPTION
I've taken the liberty of publishing bootstrap-multiselect [on npm](https://www.npmjs.com/package/bootstrap-multiselect) on NPM so it can more-easily be used with [StealJS](http://stealjs.com/) and its npm plugin.  Please let me know if you would like me to transfer it to your npm user.  I will take care of publishing subsequent versions in the meantime.