### PR TITLE
Adding the option to enable full value filtering.

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -320,6 +320,7 @@
             selectAllNumber: true,
             enableFiltering: false,
             enableCaseInsensitiveFiltering: false,
+            enableFullValueFiltering: false,
             enableClickableOptGroups: false,
             filterPlaceholder: 'Search',
             // possible options: 'text', 'value', 'both'
@@ -881,12 +882,21 @@
                                     }
 
                                     if (value !== this.options.selectAllValue && text) {
+
                                         // By default lets assume that element is not
                                         // interesting for this search.
                                         var showElement = false;
 
-                                        if (this.options.enableCaseInsensitiveFiltering && filterCandidate.toLowerCase().indexOf(this.query.toLowerCase()) > -1) {
-                                            showElement = true;
+                                        if (this.options.enableCaseInsensitiveFiltering) {
+                                            filterCandidate = filterCandidate.toLowerCase();
+                                            this.query = this.query.toLowerCase();
+                                        }
+
+                                        if( this.options.enableFullValueFiltering && this.options.filterBehavior !== 'both' ) {
+                                            var valueToMatch = filterCandidate.trim().substring(0, this.query.length);
+                                            if( this.query.indexOf(valueToMatch) > -1 ){
+                                                showElement = true;
+                                            }
                                         }
                                         else if (filterCandidate.indexOf(this.query) > -1) {
                                             showElement = true;

--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -892,9 +892,9 @@
                                             this.query = this.query.toLowerCase();
                                         }
 
-                                        if( this.options.enableFullValueFiltering && this.options.filterBehavior !== 'both' ) {
+                                        if (this.options.enableFullValueFiltering && this.options.filterBehavior !== 'both') {
                                             var valueToMatch = filterCandidate.trim().substring(0, this.query.length);
-                                            if( this.query.indexOf(valueToMatch) > -1 ){
+                                            if (this.query.indexOf(valueToMatch) > -1) {
                                                 showElement = true;
                                             }
                                         }


### PR DESCRIPTION
This feature will enable you the option to use full value filtering. For the sake of this explanation, I've set the value of `enableCaseInsensitiveFiltering ` to `true`, however, this feature supports the use of that option to be `false` also.

Imagine you have the following list of venues:
```
Aberdeen
Bath
Bristol
Hereford
Hertford
```
You want to be able to filter through these venues but by matching each letter of the venue name incrementally.

If you were to type the letter `b` with the option `enableFullValueFiltering` is set to `false`, you'd get the following results:
```
Aberdeen
Bath
Bristol
``` 
But, with that same option set to `true` you'd get the following results:
```
Bath
Bristol
```
Now modifying the search term to `ba` would return the results:
```
Bath
```