### PR TITLE
New refreshOptions method for refreshing the options.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "bootstrap-multiselect",
   "description": "Twitter Bootstrap plugin to make selects user friendly.",
   "homepage": "http://davidstutz.github.io/bootstrap-multiselect/",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "keywords": [
       "js",
       "css",

--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -151,7 +151,7 @@
         this.originalOptions = this.$select.clone()[0].options;
         this.query = '';
         this.searchTimeout = null;
-        this.lastToggledInput = null
+        this.lastToggledInput = null;
 
         this.options.multiple = this.$select.attr('multiple') === "multiple";
         this.options.onChange = $.proxy(this.options.onChange, this);
@@ -176,7 +176,7 @@
         }
         
         this.$select.hide().after(this.$container);
-    };
+    }
 
     Multiselect.prototype = {
 
@@ -513,7 +513,7 @@
                             $optionsNotThis.closest("a").css("outline", "");
                         }
                     }
-                    else {
+                    else if ($option) {
                         // Unselect option.
                         $option.prop('selected', false);
                     }
@@ -863,64 +863,71 @@
 
                             if (this.query !== event.target.value) {
                                 this.query = event.target.value;
-
-                                var currentGroup, currentGroupVisible;
-                                $.each($('li', this.$ul), $.proxy(function(index, element) {
-                                    var value = $('input', element).length > 0 ? $('input', element).val() : "";
-                                    var text = $('label', element).text();
-
-                                    var filterCandidate = '';
-                                    if ((this.options.filterBehavior === 'text')) {
-                                        filterCandidate = text;
-                                    }
-                                    else if ((this.options.filterBehavior === 'value')) {
-                                        filterCandidate = value;
-                                    }
-                                    else if (this.options.filterBehavior === 'both') {
-                                        filterCandidate = text + '\n' + value;
-                                    }
-
-                                    if (value !== this.options.selectAllValue && text) {
-                                        // By default lets assume that element is not
-                                        // interesting for this search.
-                                        var showElement = false;
-
-                                        if (this.options.enableCaseInsensitiveFiltering && filterCandidate.toLowerCase().indexOf(this.query.toLowerCase()) > -1) {
-                                            showElement = true;
-                                        }
-                                        else if (filterCandidate.indexOf(this.query) > -1) {
-                                            showElement = true;
-                                        }
-
-                                        // Toggle current element (group or group item) according to showElement boolean.
-                                        $(element).toggle(showElement).toggleClass('filter-hidden', !showElement);
-                                        
-                                        // Differentiate groups and group items.
-                                        if ($(element).hasClass('multiselect-group')) {
-                                            // Remember group status.
-                                            currentGroup = element;
-                                            currentGroupVisible = showElement;
-                                        }
-                                        else {
-                                            // Show group name when at least one of its items is visible.
-                                            if (showElement) {
-                                                $(currentGroup).show().removeClass('filter-hidden');
-                                            }
-                                            
-                                            // Show all group items when group name satisfies filter.
-                                            if (!showElement && currentGroupVisible) {
-                                                $(element).show().removeClass('filter-hidden');
-                                            }
-                                        }
-                                    }
-                                }, this));
+                                this.updateVisibilityByFilter();
                             }
 
-                            this.updateSelectAll();
                         }, this), 300, this);
                     }, this));
                 }
             }
+        },
+        
+        /**
+         * Update visibilities of the options
+         */
+        updateVisibilityByFilter: function () {
+            var currentGroup, currentGroupVisible;
+            $.each($('li', this.$ul), $.proxy(function (index, element) {
+                var value = $('input', element).length > 0 ? $('input', element).val() : "";
+                var text = $('label', element).text();
+                
+                var filterCandidate = '';
+                if ((this.options.filterBehavior === 'text')) {
+                    filterCandidate = text;
+                }
+                else if ((this.options.filterBehavior === 'value')) {
+                    filterCandidate = value;
+                }
+                else if (this.options.filterBehavior === 'both') {
+                    filterCandidate = text + '\n' + value;
+                }
+                
+                if (value !== this.options.selectAllValue && text) {
+                    // By default lets assume that element is not
+                    // interesting for this search.
+                    var showElement = false;
+                    
+                    if (this.options.enableCaseInsensitiveFiltering && filterCandidate.toLowerCase().indexOf(this.query.toLowerCase()) > -1) {
+                        showElement = true;
+                    }
+                    else if (filterCandidate.indexOf(this.query) > -1) {
+                        showElement = true;
+                    }
+                    
+                    // Toggle current element (group or group item) according to showElement boolean.
+                    $(element).toggle(showElement).toggleClass('filter-hidden', !showElement);
+                    
+                    // Differentiate groups and group items.
+                    if ($(element).hasClass('multiselect-group')) {
+                        // Remember group status.
+                        currentGroup = element;
+                        currentGroupVisible = showElement;
+                    }
+                    else {
+                        // Show group name when at least one of its items is visible.
+                        if (showElement) {
+                            $(currentGroup).show().removeClass('filter-hidden');
+                        }
+                        
+                        // Show all group items when group name satisfies filter.
+                        if (!showElement && currentGroupVisible) {
+                            $(element).show().removeClass('filter-hidden');
+                        }
+                    }
+                }
+            }, this));
+            
+            this.updateSelectAll();
         },
 
         /**
@@ -931,9 +938,18 @@
             this.$select.show();
             this.$select.data('multiselect', null);
         },
+        
+        /**
+         * Refreshes the multiselect options based on the option of the select element.
+         */
+        refreshOptions: function () {
+            this.$ul.children('li').not('.filter').remove();
+            this.buildDropdownOptions();
+            this.updateVisibilityByFilter();
+        },
 
         /**
-         * Refreshs the multiselect based on the selected options of the select.
+         * Refreshes the multiselect based on the selected options of the select element.
          */
         refresh: function() {
             $('option', this.$select).each($.proxy(function(index, element) {

--- a/tests/spec/bootstrap-multiselect.js
+++ b/tests/spec/bootstrap-multiselect.js
@@ -153,6 +153,27 @@ describe('Bootstrap Multiselect "Core".', function() {
         }
     });
     
+    it('Should preserve the checkbox selections after using refreshOptions.', function () {
+        var $select = $('#multiselect');
+        for (var i = 100; i < 110; i++) {
+            var $option = $('<option value="' + i + '">' + i + '</option>');
+            $select.append($option);
+        }
+        
+        expect($('#multiselect option').length).toBe(109);
+        expect($('#multiselect-container input[type="checkbox"]').length).toBe(99);
+        
+        $('#multiselect').multiselect('refreshOptions');
+        
+        expect($('#multiselect option').length).toBe(109);
+        expect($('#multiselect-container input[type="checkbox"]').length).toBe(109);
+        expect($('#multiselect-container input[type="checkbox"]:checked').length).toBe(9);
+        
+        for (var i = 1; i < 10; i++) {
+            expect($('#multiselect option[value="' + i + '"]').prop('selected')).toBe(true);
+        }
+    });
+    
     it('Should remove container, button and ul after destroy.', function() {
         $('#multiselect').multiselect('destroy');
         


### PR DESCRIPTION
Refactored switching of visiblity of elements in buildFilter to new updateVisibilityByFilter method. Then added new refreshOptions for refreshing of the options without rebuilding the whole UI --- preserving filter and keyboard cursor focus this way.

Originally needed this feature for the Knockout bindingHandlers: Didn't want to lost keyboard focus and other UI state when updating the options dynamically. This feature could help also at least with issue #483 ("When reconstructs the component the state is lost. To what was typed disappears").