### PR TITLE
Data provider HTML custom data attributes

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1157,6 +1157,7 @@
                     
                     $tag = $('<optgroup/>').attr({
                         label: option.label || 'Group ' + groupCounter,
+                        value: option.value,
                         disabled: !!option.disabled
                     });
                     

--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1206,23 +1206,41 @@
                     });
                     
                     forEach(option.children, function(subOption) { // add children option tags
-                        $tag.append($('<option/>').attr({
+                        /* Note: this could be copied again to OptGroup if you think option groups may have data attributes */
+                        //Decouple attribute assignment from .attr()      
+                        var attributes  = {
                             value: subOption.value,
                             label: subOption.label || subOption.value,
                             title: subOption.title,
                             selected: !!subOption.selected,
                             disabled: !!subOption.disabled
-                        }));
+                        }
+                       
+                       //Loop through attributes object and add key-value for each attribute    
+                       for (var key in subOption.attributes) {
+                            attributes['data-' + key] = subOption.attributes[key];
+                       }
+                        //Append original attributes + new data attributes to option       
+                        $tag.append($('<option/>').attr(attributes));
                     });
                 }
                 else {
-                    $tag = $('<option/>').attr({
+                    //Decouple attribute assignment from .attr()                     
+                    var attributes = 
+                    {
                         value: option.value,
                         label: option.label || option.value,
                         title: option.title,
                         selected: !!option.selected,
                         disabled: !!option.disabled
-                    });
+                    }
+                    
+                    //Loop through attributes object and add key-value for each attribute    
+                    for (var key in option.attributes) {
+                      attributes['data-' + key] = option.attributes[key];
+                    }
+                    //Append original attributes + new data attributes to option
+                    $tag =   $('<option/>').attr(attributes);
                 }
                 
                 $select.append($tag);

--- a/index.html
+++ b/index.html
@@ -3421,6 +3421,79 @@
 &lt;select id=&quot;example-dataprovider-optgroups&quot; multiple=&quot;multiple&quot;&gt;&lt;/select&gt;
 </pre>
                                     </div>
+                                    
+                                                                        <p>
+                                        You can add custom data attributes on option group children and non-grouped options:
+                                    </p>
+                                    <p>
+                                       Renders as: <pre class="prettyprint">&lt;option value=&quot;1&quot; label=&quot;Option 1&quot; selected=&quot;selected&quot; data-some-attribute=&quot;1&quot; data-another-attribute=&quot;false&quot;&gt;&lt;/option&gt;
+&lt;option value=&quot;2&quot; label=&quot;Option 2&quot; data-some-attribute=&quot;2&quot;&gt;&lt;/option&gt;</pre>
+                                    </p>
+                                    
+                                    <div class="example">
+                                        <div class="btn-group">
+                                            <script type="text/javascript">
+                                                $(document).ready(function() {
+                                                    $('#example-dataprovider-data-attributes').multiselect();
+
+                                                  var optionsData =[
+                                                                  {
+                                                                    "label": "Option 1",
+                                                                    "value": 1,
+                                                                    "selected": true,
+                                                                    "attributes": {
+                                                                      "some-attribute": 1,
+                                                                      "another-attribute": false
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "label": "Option 2",
+                                                                    "value": 2,
+                                                                    "selected": false,
+                                                                    "attributes": {
+                                                                      "some-attribute": 2
+                                                                    }
+                                                                  }
+                                                                ];
+                                                    $('#example-dataprovider-data-attributes').multiselect('dataprovider', optionsData);
+                                                });
+                                            </script>
+                                            <select id="example-dataprovider-data-attributes" multiple="multiple"></select>
+                                            
+                                         
+                                        </div>
+                                    </div>
+
+                                    <div class="highlight">
+<pre class="prettyprint linenums">
+      $(&#39;#example-dataprovider-data-attributes&#39;).multiselect();
+
+      var optionsData =[
+                      {
+                        &quot;label&quot;: &quot;Option 1&quot;,
+                        &quot;value&quot;: 1,
+                        &quot;selected&quot;: true,
+                        &quot;attributes&quot;: {
+                          &quot;some-attribute&quot;: 1,
+                          &quot;another-attribute&quot;: false
+                        }
+                      },
+                      {
+                        &quot;label&quot;: &quot;Option 2&quot;,
+                        &quot;value&quot;: 2,
+                        &quot;selected&quot;: false,
+                        &quot;attributes&quot;: {
+                          &quot;some-attribute&quot;: 2
+                        }
+                      }
+                    ];
+        $(&#39;#example-dataprovider-data-attributes&#39;).multiselect(&#39;dataprovider&#39;, optionsData);
+    });
+&lt;/script&gt;
+&lt;select id=&quot;example-dataprovider-data-attributes&quot; multiple=&quot;multiple&quot;&gt;&lt;/select&gt;
+</pre>
+                                    </div>
+                                    
                                 </td>
                             </tr>
                             <tr>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
         <link rel="stylesheet" href="dist/css/bootstrap-multiselect.css" type="text/css">
         <script type="text/javascript" src="dist/js/bootstrap-multiselect.js"></script>
-       <!-- <script type="text/javascript" src="dist/js/bootstrap-multiselect-collapsible-groups.js"></script>-->
+        <script type="text/javascript" src="dist/js/bootstrap-multiselect-collapsible-groups.js"></script>
 
         <script type="text/javascript">
             $(document).ready(function() {

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
         <link rel="stylesheet" href="dist/css/bootstrap-multiselect.css" type="text/css">
         <script type="text/javascript" src="dist/js/bootstrap-multiselect.js"></script>
-        <script type="text/javascript" src="dist/js/bootstrap-multiselect-collapsible-groups.js"></script>
+       <!-- <script type="text/javascript" src="dist/js/bootstrap-multiselect-collapsible-groups.js"></script>-->
 
         <script type="text/javascript">
             $(document).ready(function() {


### PR DESCRIPTION
Modified dataprovider to support the addition of HTML custom data
attributes.

Decoupled attribute assignment from .attr() into a separate variable to
support OptGroup children as well as standard lists.

Pass an attribute key to the option data with as many key-values
(data-attributes) as required.

index.html updated with appropriate example.

More info:
http://stackoverflow.com/questions/31761661/dynamically-add-attributes-as-object-properties