### PR TITLE
Added additional data attr in each option element

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1213,6 +1213,7 @@
                             selected: !!subOption.selected,
                             disabled: !!subOption.disabled
                         }));
+                        $tag.data("additional", subOption.additional);
                     });
                 }
                 else {
@@ -1223,6 +1224,7 @@
                         selected: !!option.selected,
                         disabled: !!option.disabled
                     });
+                    $tag.data("additional", option.additional);
                 }
                 
                 $select.append($tag);


### PR DESCRIPTION
There are certain cases where a need to provide a data object instead of a single label is necessary. For example, in the following case, I need to be able to provide data for both the labels (name and followers).
<img width="281" alt="screen shot 2015-09-14 at 3 15 27 pm" src="https://cloud.githubusercontent.com/assets/7127018/9846979/9aa86ba8-5af3-11e5-8b07-dc9bd88067ee.png">
Therefore, I added data on the option element with key - "additional" which could put any additional data that user wants to send with the option.