### PR TITLE
Fixed trigger onSelectAll run

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -298,7 +298,7 @@
             /**
              * Triggered on select all.
              */
-            onSelectAll: function() {
+            onSelectAll: function(checked) {
                 
             },
             enableHTML: false,
@@ -1291,11 +1291,14 @@
                 if (checkedBoxesLength > 0 && checkedBoxesLength === allBoxesLength) {
                     selectAllInput.prop("checked", true);
                     selectAllLi.addClass(this.options.selectedClass);
-                    this.options.onSelectAll();
+                    this.options.onSelectAll(true);
                 }
                 else {
                     selectAllInput.prop("checked", false);
                     selectAllLi.removeClass(this.options.selectedClass);
+                    if (checkedBoxesLength === 0) {
+                    this.options.onSelectAll(false);
+                    }
                 }
             }
         },


### PR DESCRIPTION
When deselecting Select All trigger onSelectAll should behave different when checked state replaces  unchecked and when unchecked states replaces checked (or when you manually deselect all options state)