### PR TITLE
made entire row clickable

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -725,7 +725,7 @@
                 $('li.multiselect-group', this.$ul).on('click', $.proxy(function(event) {
                     event.stopPropagation();
                     console.log('test');
-                    var group = $(event.target).parent();
+                    var group = $(event.delegateTarget);
 
                     // Search all option in optgroup
                     var $options = group.nextUntil('li.multiselect-group');


### PR DESCRIPTION
This pull request fixes the issue https://github.com/davidstutz/bootstrap-multiselect/issues/626, The problem is when the user clicks on li.multiselect-group code is try to accessing _parent element of li.multiselect-group_ causing the issue.So with event.delegateTarget we always select li.multiselect-group irrespective of user clicking on child label element or li.multiselect-group
