### PR TITLE
Add Diacritic support for filtering text

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1,23 +1,23 @@
 /**
  * Bootstrap Multiselect (https://github.com/davidstutz/bootstrap-multiselect)
- * 
+ *
  * Apache License, Version 2.0:
  * Copyright (c) 2012 - 2015 David Stutz
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a
  * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations
  * under the License.
- * 
+ *
  * BSD 3-Clause License:
  * Copyright (c) 2012 - 2015 David Stutz
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *    - Redistributions of source code must retain the above copyright notice,
@@ -28,7 +28,7 @@
  *    - Neither the name of David Stutz nor the names of its contributors may be
  *      used to endorse or promote products derived from this software without
  *      specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
  * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
@@ -48,7 +48,7 @@
         ko.bindingHandlers.multiselect = {
             after: ['options', 'value', 'selectedOptions', 'enable', 'disable'],
 
-            init: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
+            init: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
                 var $element = $(element);
                 var config = ko.toJS(valueAccessor());
 
@@ -58,9 +58,9 @@
                     var options = allBindings.get('options');
                     if (ko.isObservable(options)) {
                         ko.computed({
-                            read: function() {
+                            read: function () {
                                 options();
-                                setTimeout(function() {
+                                setTimeout(function () {
                                     var ms = $element.data('multiselect');
                                     if (ms)
                                         ms.updateOriginalOptions();//Not sure how beneficial this is.
@@ -79,14 +79,14 @@
                     var value = allBindings.get('value');
                     if (ko.isObservable(value)) {
                         ko.computed({
-                            read: function() {
+                            read: function () {
                                 value();
-                                setTimeout(function() {
+                                setTimeout(function () {
                                     $element.multiselect('refresh');
                                 }, 1);
                             },
                             disposeWhenNodeIsRemoved: element
-                        }).extend({ rateLimit: 100, notifyWhenChangesStop: true });
+                        }).extend({rateLimit: 100, notifyWhenChangesStop: true});
                     }
                 }
 
@@ -96,14 +96,14 @@
                     var selectedOptions = allBindings.get('selectedOptions');
                     if (ko.isObservable(selectedOptions)) {
                         ko.computed({
-                            read: function() {
+                            read: function () {
                                 selectedOptions();
-                                setTimeout(function() {
+                                setTimeout(function () {
                                     $element.multiselect('refresh');
                                 }, 1);
                             },
                             disposeWhenNodeIsRemoved: element
-                        }).extend({ rateLimit: 100, notifyWhenChangesStop: true });
+                        }).extend({rateLimit: 100, notifyWhenChangesStop: true});
                     }
                 }
 
@@ -124,7 +124,7 @@
                                 setEnabled(enable());
                             },
                             disposeWhenNodeIsRemoved: element
-                        }).extend({ rateLimit: 100, notifyWhenChangesStop: true });
+                        }).extend({rateLimit: 100, notifyWhenChangesStop: true});
                     } else {
                         setEnabled(enable);
                     }
@@ -138,18 +138,18 @@
                                 setEnabled(!disable());
                             },
                             disposeWhenNodeIsRemoved: element
-                        }).extend({ rateLimit: 100, notifyWhenChangesStop: true });
+                        }).extend({rateLimit: 100, notifyWhenChangesStop: true});
                     } else {
                         setEnabled(!disable);
                     }
                 }
 
-                ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
+                ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
                     $element.multiselect('destroy');
                 });
             },
 
-            update: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
+            update: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
                 var $element = $(element);
                 var config = ko.toJS(valueAccessor());
 
@@ -175,12 +175,12 @@
     function Multiselect(select, options) {
 
         this.$select = $(select);
-        
+
         // Placeholder via data attributes
         if (this.$select.attr("data-placeholder")) {
             options.nonSelectedText = this.$select.data("placeholder");
         }
-        
+
         this.options = this.mergeOptions($.extend({}, options, this.$select.data()));
 
         // Initialization.
@@ -197,7 +197,7 @@
         this.options.onDropdownShown = $.proxy(this.options.onDropdownShown, this);
         this.options.onDropdownHidden = $.proxy(this.options.onDropdownHidden, this);
         this.options.onInitialized = $.proxy(this.options.onInitialized, this);
-        
+
         // Build select all if enabled.
         this.buildContainer();
         this.buildButton();
@@ -212,7 +212,7 @@
         if (this.options.disableIfEmpty && $('option', this.$select).length <= 0) {
             this.disable();
         }
-        
+
         this.$select.hide().after(this.$container);
         this.options.onInitialized(this.$select, this.$container);
     }
@@ -224,25 +224,25 @@
              * Default text function will either print 'None selected' in case no
              * option is selected or a list of the selected options up to a length
              * of 3 selected options.
-             * 
+             *
              * @param {jQuery} options
              * @param {jQuery} select
              * @returns {String}
              */
-            buttonText: function(options, select) {
-                if (this.disabledText.length > 0 
-                        && (this.disableIfEmpty || select.prop('disabled')) 
-                        && options.length == 0) {
-                    
+            buttonText: function (options, select) {
+                if (this.disabledText.length > 0
+                    && (this.disableIfEmpty || select.prop('disabled'))
+                    && options.length == 0) {
+
                     return this.disabledText;
                 }
                 else if (options.length === 0) {
                     return this.nonSelectedText;
                 }
-                else if (this.allSelectedText 
-                        && options.length === $('option', $(select)).length 
-                        && $('option', $(select)).length !== 1 
-                        && this.multiple) {
+                else if (this.allSelectedText
+                    && options.length === $('option', $(select)).length
+                    && $('option', $(select)).length !== 1
+                    && this.multiple) {
 
                     if (this.selectAllNumber) {
                         return this.allSelectedText + ' (' + options.length + ')';
@@ -257,30 +257,30 @@
                 else {
                     var selected = '';
                     var delimiter = this.delimiterText;
-                    
-                    options.each(function() {
+
+                    options.each(function () {
                         var label = ($(this).attr('label') !== undefined) ? $(this).attr('label') : $(this).text();
                         selected += label + delimiter;
                     });
-                    
+
                     return selected.substr(0, selected.length - 2);
                 }
             },
             /**
              * Updates the title of the button similar to the buttonText function.
-             * 
+             *
              * @param {jQuery} options
              * @param {jQuery} select
              * @returns {@exp;selected@call;substr}
              */
-            buttonTitle: function(options, select) {
+            buttonTitle: function (options, select) {
                 if (options.length === 0) {
                     return this.nonSelectedText;
                 }
                 else {
                     var selected = '';
                     var delimiter = this.delimiterText;
-                    
+
                     options.each(function () {
                         var label = ($(this).attr('label') !== undefined) ? $(this).attr('label') : $(this).text();
                         selected += label + delimiter;
@@ -294,7 +294,7 @@
              * @param {jQuery} element
              * @returns {String}
              */
-            optionLabel: function(element){
+            optionLabel: function (element) {
                 return $(element).attr('label') || $(element).text();
             },
             /**
@@ -303,18 +303,18 @@
              * @param {jQuery} element
              * @returns {String}
              */
-            optionClass: function(element) {
+            optionClass: function (element) {
                 return $(element).attr('class') || '';
             },
             /**
              * Triggered on change of the multiselect.
-             * 
+             *
              * Not triggered when selecting/deselecting options manually.
-             * 
+             *
              * @param {jQuery} option
              * @param {Boolean} checked
              */
-            onChange : function(option, checked) {
+            onChange: function (option, checked) {
 
             },
             /**
@@ -322,7 +322,7 @@
              *
              * @param {jQuery} event
              */
-            onDropdownShow: function(event) {
+            onDropdownShow: function (event) {
 
             },
             /**
@@ -330,30 +330,30 @@
              *
              * @param {jQuery} event
              */
-            onDropdownHide: function(event) {
+            onDropdownHide: function (event) {
 
             },
             /**
              * Triggered after the dropdown is shown.
-             * 
+             *
              * @param {jQuery} event
              */
-            onDropdownShown: function(event) {
-                
+            onDropdownShown: function (event) {
+
             },
             /**
              * Triggered after the dropdown is hidden.
-             * 
+             *
              * @param {jQuery} event
              */
-            onDropdownHidden: function(event) {
-                
+            onDropdownHidden: function (event) {
+
             },
             /**
              * Triggered on select all.
              */
-            onSelectAll: function(checked) {
-                
+            onSelectAll: function (checked) {
+
             },
             /**
              * Triggered after initializing.
@@ -361,7 +361,7 @@
              * @param {jQuery} $select
              * @param {jQuery} $container
              */
-            onInitialized: function($select, $container) {
+            onInitialized: function ($select, $container) {
 
             },
             enableHTML: false,
@@ -385,6 +385,7 @@
             selectAllJustVisible: true,
             enableFiltering: false,
             enableCaseInsensitiveFiltering: false,
+            enableReplaceDiacritics: true,
             enableFullValueFiltering: false,
             enableClickableOptGroups: false,
             enableCollapsibelOptGroups: false,
@@ -416,7 +417,7 @@
         /**
          * Builds the container of the multiselect.
          */
-        buildContainer: function() {
+        buildContainer: function () {
             this.$container = $(this.options.buttonContainer);
             this.$container.on('show.bs.dropdown', this.options.onDropdownShow);
             this.$container.on('hide.bs.dropdown', this.options.onDropdownHide);
@@ -427,7 +428,7 @@
         /**
          * Builds the button of the multiselect.
          */
-        buildButton: function() {
+        buildButton: function () {
             this.$button = $(this.options.templates.button).addClass(this.options.buttonClass);
             if (this.$select.attr('class') && this.options.inheritClass) {
                 this.$button.addClass(this.$select.attr('class'));
@@ -443,9 +444,9 @@
             // Manually add button width if set.
             if (this.options.buttonWidth && this.options.buttonWidth !== 'auto') {
                 this.$button.css({
-                    'width' : this.options.buttonWidth,
-                    'overflow' : 'hidden',
-                    'text-overflow' : 'ellipsis'
+                    'width': this.options.buttonWidth,
+                    'overflow': 'hidden',
+                    'text-overflow': 'ellipsis'
                 });
                 this.$container.css({
                     'width': this.options.buttonWidth
@@ -464,7 +465,7 @@
         /**
          * Builds the ul representing the dropdown menu.
          */
-        buildDropdown: function() {
+        buildDropdown: function () {
 
             // Build ul.
             this.$ul = $(this.options.templates.ul);
@@ -482,12 +483,12 @@
                     'overflow-x': 'hidden'
                 });
             }
-            
+
             if (this.options.dropUp) {
-                
-                var height = Math.min(this.options.maxHeight, $('option[data-role!="divider"]', this.$select).length*26 + $('option[data-role="divider"]', this.$select).length*19 + (this.options.includeSelectAllOption ? 26 : 0) + (this.options.enableFiltering || this.options.enableCaseInsensitiveFiltering ? 44 : 0));
+
+                var height = Math.min(this.options.maxHeight, $('option[data-role!="divider"]', this.$select).length * 26 + $('option[data-role="divider"]', this.$select).length * 19 + (this.options.includeSelectAllOption ? 26 : 0) + (this.options.enableFiltering || this.options.enableCaseInsensitiveFiltering ? 44 : 0));
                 var moveCalc = height + 34;
-                
+
                 this.$ul.css({
                     'max-height': height + 'px',
                     'overflow-y': 'auto',
@@ -495,24 +496,24 @@
                     'margin-top': "-" + moveCalc + 'px'
                 });
             }
-            
+
             this.$container.append(this.$ul);
         },
 
         /**
          * Build the dropdown options and binds all nessecary events.
-         * 
+         *
          * Uses createDivider and createOptionValue to create the necessary options.
          */
-        buildDropdownOptions: function() {
+        buildDropdownOptions: function () {
 
-            this.$select.children().each($.proxy(function(index, element) {
+            this.$select.children().each($.proxy(function (index, element) {
 
                 var $element = $(element);
                 // Support optgroups and options without a group simultaneously.
                 var tag = $element.prop('tagName')
                     .toLowerCase();
-            
+
                 if ($element.prop('value') === this.options.selectAllValue) {
                     return;
                 }
@@ -535,7 +536,7 @@
             }, this));
 
             // Bind the change event on the dropdown elements.
-            $('li input', this.$ul).on('change', $.proxy(function(event) {
+            $('li input', this.$ul).on('change', $.proxy(function (event) {
                 var $target = $(event.target);
 
                 var checked = $target.prop('checked') || false;
@@ -597,7 +598,7 @@
                         // Unselect option.
                         $option.prop('selected', false);
                     }
-                    
+
                     // To prevent select all from firing onChange: #575
                     this.options.onChange($option, checked);
                 }
@@ -607,25 +608,25 @@
                 this.updateButtonText();
                 this.updateSelectAll();
 
-                if(this.options.preventInputChangeEvent) {
+                if (this.options.preventInputChangeEvent) {
                     return false;
                 }
             }, this));
 
-            $('li a', this.$ul).on('mousedown', function(e) {
+            $('li a', this.$ul).on('mousedown', function (e) {
                 if (e.shiftKey) {
                     // Prevent selecting text by Shift+click
                     return false;
                 }
             });
-        
-            $('li a', this.$ul).on('touchstart click', $.proxy(function(event) {
+
+            $('li a', this.$ul).on('touchstart click', $.proxy(function (event) {
                 event.stopPropagation();
 
                 var $target = $(event.target);
-                
+
                 if (event.shiftKey && this.options.multiple) {
-                    if($target.is("label")){ // Handles checkbox selection manually (see https://github.com/davidstutz/bootstrap-multiselect/issues/431)
+                    if ($target.is("label")) { // Handles checkbox selection manually (see https://github.com/davidstutz/bootstrap-multiselect/issues/431)
                         event.preventDefault();
                         $target = $target.find("input");
                         $target.prop("checked", !$target.prop("checked"));
@@ -635,41 +636,41 @@
                     if (this.lastToggledInput !== null && this.lastToggledInput !== $target) { // Make sure we actually have a range
                         var from = $target.closest("li").index();
                         var to = this.lastToggledInput.closest("li").index();
-                        
+
                         if (from > to) { // Swap the indices
                             var tmp = to;
                             to = from;
                             from = tmp;
                         }
-                        
+
                         // Make sure we grab all elements since slice excludes the last index
                         ++to;
-                        
+
                         // Change the checkboxes and underlying options
                         var range = this.$ul.find("li").slice(from, to).find("input");
-                        
+
                         range.prop('checked', checked);
-                        
+
                         if (this.options.selectedClass) {
                             range.closest('li')
                                 .toggleClass(this.options.selectedClass, checked);
                         }
-                        
+
                         for (var i = 0, j = range.length; i < j; i++) {
                             var $checkbox = $(range[i]);
 
                             var $option = this.getOptionByValue($checkbox.val());
 
                             $option.prop('selected', checked);
-                        }                   
+                        }
                     }
-                    
+
                     // Trigger the select "change" event
                     $target.trigger("change");
                 }
-                
+
                 // Remembers last clicked option
-                if($target.is("input") && !$target.closest("li").is(".multiselect-item")){
+                if ($target.is("input") && !$target.closest("li").is(".multiselect-item")) {
                     this.lastToggledInput = $target;
                 }
 
@@ -677,7 +678,7 @@
             }, this));
 
             // Keyboard support.
-            this.$container.off('keydown.multiselect').on('keydown.multiselect', $.proxy(function(event) {
+            this.$container.off('keydown.multiselect').on('keydown.multiselect', $.proxy(function (event) {
                 if ($('input[type="text"]', this.$container).is(':focus')) {
                     return;
                 }
@@ -721,8 +722,8 @@
                 }
             }, this));
 
-            if(this.options.enableClickableOptGroups && this.options.multiple) {
-                $('li.multiselect-group', this.$ul).on('click', $.proxy(function(event) {
+            if (this.options.enableClickableOptGroups && this.options.multiple) {
+                $('li.multiselect-group', this.$ul).on('click', $.proxy(function (event) {
                     event.stopPropagation();
                     console.log('test');
                     var group = $(event.target).parent();
@@ -735,8 +736,8 @@
                     var allChecked = true;
                     var optionInputs = $visibleOptions.find('input');
                     var values = [];
-                    
-                    optionInputs.each(function() {
+
+                    optionInputs.each(function () {
                         allChecked = allChecked && $(this).prop('checked');
                         values.push($(this).val());
                     });
@@ -747,83 +748,83 @@
                     else {
                         this.deselect(values, false);
                     }
-                    
+
                     this.options.onChange(optionInputs, !allChecked);
-               }, this));
+                }, this));
             }
 
             if (this.options.enableCollapsibleOptGroups && this.options.multiple) {
                 $("li.multiselect-group input", this.$ul).off();
-                $("li.multiselect-group", this.$ul).siblings().not("li.multiselect-group, li.multiselect-all", this.$ul).each( function () {
+                $("li.multiselect-group", this.$ul).siblings().not("li.multiselect-group, li.multiselect-all", this.$ul).each(function () {
                     $(this).toggleClass('hidden', true);
                 });
-                
-                $("li.multiselect-group", this.$ul).on("click", $.proxy(function(group) {
+
+                $("li.multiselect-group", this.$ul).on("click", $.proxy(function (group) {
                     group.stopPropagation();
                 }, this));
-                
-                $("li.multiselect-group > a > b", this.$ul).on("click", $.proxy(function(t) {
+
+                $("li.multiselect-group > a > b", this.$ul).on("click", $.proxy(function (t) {
                     t.stopPropagation();
                     var n = $(t.target).closest('li');
                     var r = n.nextUntil("li.multiselect-group");
                     var i = true;
-                    
-                    r.each(function() {
+
+                    r.each(function () {
                         i = i && $(this).hasClass('hidden');
                     });
-                    
+
                     r.toggleClass('hidden', !i);
                 }, this));
-                
-                $("li.multiselect-group > a > input", this.$ul).on("change", $.proxy(function(t) {
+
+                $("li.multiselect-group > a > input", this.$ul).on("change", $.proxy(function (t) {
                     t.stopPropagation();
                     var n = $(t.target).closest('li');
                     var r = n.nextUntil("li.multiselect-group", ':not(.disabled)');
                     var s = r.find("input");
-                    
+
                     var i = true;
-                    s.each(function() {
+                    s.each(function () {
                         i = i && $(this).prop("checked");
                     });
-                    
+
                     s.prop("checked", !i).trigger("change");
                 }, this));
-                
+
                 // Set the initial selection state of the groups.
-                $('li.multiselect-group', this.$ul).each(function() {
+                $('li.multiselect-group', this.$ul).each(function () {
                     var r = $(this).nextUntil("li.multiselect-group", ':not(.disabled)');
                     var s = r.find("input");
-                    
+
                     var i = true;
-                    s.each(function() {
+                    s.each(function () {
                         i = i && $(this).prop("checked");
                     });
-                    
+
                     $(this).find('input').prop("checked", i);
                 });
-                
+
                 // Update the group checkbox based on new selections among the
                 // corresponding children.
-                $("li input", this.$ul).on("change", $.proxy(function(t) {
+                $("li input", this.$ul).on("change", $.proxy(function (t) {
                     t.stopPropagation();
                     var n = $(t.target).closest('li');
                     var r1 = n.prevUntil("li.multiselect-group", ':not(.disabled)');
                     var r2 = n.nextUntil("li.multiselect-group", ':not(.disabled)');
                     var s1 = r1.find("input");
                     var s2 = r2.find("input");
-                    
+
                     var i = $(t.target).prop('checked');
-                    s1.each(function() {
+                    s1.each(function () {
                         i = i && $(this).prop("checked");
                     });
-                    
-                    s2.each(function() {
+
+                    s2.each(function () {
                         i = i && $(this).prop("checked");
                     });
-                    
+
                     n.prevAll('.multiselect-group').find('input').prop('checked', i);
                 }, this));
-                
+
                 $("li.multiselect-all", this.$ul).css('background', '#f3f3f3').css('border-bottom', '1px solid #eaeaea');
                 $("li.multiselect-group > a, li.multiselect-all > a > label.checkbox", this.$ul).css('padding', '3px 20px 3px 35px');
                 $("li.multiselect-group > a > input", this.$ul).css('margin', '4px 0px 5px -20px');
@@ -835,7 +836,7 @@
          *
          * @param {jQuery} element
          */
-        createOptionValue: function(element) {
+        createOptionValue: function (element) {
             var $element = $(element);
             if ($element.is(':selected')) {
                 $element.prop('selected', true);
@@ -858,7 +859,7 @@
             else {
                 $label.text(" " + label);
             }
-        
+
             var $checkbox = $('<input/>').attr('type', inputType);
 
             if (this.options.checkboxName) {
@@ -901,7 +902,7 @@
          *
          * @param {jQuery} element
          */
-        createDivider: function(element) {
+        createDivider: function (element) {
             var $divider = $(this.options.templates.divider);
             this.$ul.append($divider);
         },
@@ -911,7 +912,7 @@
          *
          * @param {jQuery} group
          */
-        createOptgroup: function(group) {            
+        createOptgroup: function (group) {
             if (this.options.enableCollapsibleOptGroups && this.options.multiple) {
                 var label = $(group).attr("label");
                 var value = $(group).attr("value");
@@ -924,7 +925,7 @@
                 if ($(group).is(":disabled")) {
                     r.addClass("disabled")
                 }
-                $("option", group).each($.proxy(function($, group) {
+                $("option", group).each($.proxy(function ($, group) {
                     this.createOptionValue(group)
                 }, this))
             }
@@ -952,7 +953,7 @@
                 }
 
                 // Add the options of the group.
-                $('option', group).each($.proxy(function(index, element) {
+                $('option', group).each($.proxy(function (index, element) {
                     this.createOptionValue(element);
                 }, this));
             }
@@ -960,18 +961,18 @@
 
         /**
          * Build the select all.
-         * 
+         *
          * Checks if a select all has already been created.
          */
-        buildSelectAll: function() {
+        buildSelectAll: function () {
             if (typeof this.options.selectAllValue === 'number') {
                 this.options.selectAllValue = this.options.selectAllValue.toString();
             }
-            
+
             var alreadyHasSelectAll = this.hasSelectAll();
 
             if (!alreadyHasSelectAll && this.options.includeSelectAllOption && this.options.multiple
-                    && $('option', this.$select).length > this.options.includeSelectAllIfMoreThan) {
+                && $('option', this.$select).length > this.options.includeSelectAllIfMoreThan) {
 
                 // Check whether to add a divider after the select all.
                 if (this.options.includeSelectAllDivider) {
@@ -980,21 +981,21 @@
 
                 var $li = $(this.options.templates.li);
                 $('label', $li).addClass("checkbox");
-                
+
                 if (this.options.enableHTML) {
                     $('label', $li).html(" " + this.options.selectAllText);
                 }
                 else {
                     $('label', $li).text(" " + this.options.selectAllText);
                 }
-                
+
                 if (this.options.selectAllName) {
                     $('label', $li).prepend('<input type="checkbox" name="' + this.options.selectAllName + '" />');
                 }
                 else {
                     $('label', $li).prepend('<input type="checkbox" />');
                 }
-                
+
                 var $checkbox = $('input', $li);
                 $checkbox.val(this.options.selectAllValue);
 
@@ -1011,7 +1012,7 @@
         /**
          * Builds the filter.
          */
-        buildFilter: function() {
+        buildFilter: function () {
 
             // Build filter if filtering OR case insensitive filtering is enabled and the number of options exceeds (or equals) enableFilterLength.
             if (this.options.enableFiltering || this.options.enableCaseInsensitiveFiltering) {
@@ -1021,11 +1022,11 @@
 
                     this.$filter = $(this.options.templates.filter);
                     $('input', this.$filter).attr('placeholder', this.options.filterPlaceholder);
-                    
+
                     // Adds optional filter clear button
-                    if(this.options.includeFilterClearBtn){
+                    if (this.options.includeFilterClearBtn) {
                         var clearBtn = $(this.options.templates.filterClearBtn);
-                        clearBtn.on('click', $.proxy(function(event){
+                        clearBtn.on('click', $.proxy(function (event) {
                             clearTimeout(this.searchTimeout);
                             this.$filter.find('.multiselect-search').val('');
                             $('li', this.$ul).show().removeClass("filter-hidden");
@@ -1033,27 +1034,27 @@
                         }, this));
                         this.$filter.find('.input-group').append(clearBtn);
                     }
-                    
+
                     this.$ul.prepend(this.$filter);
 
-                    this.$filter.val(this.query).on('click', function(event) {
+                    this.$filter.val(this.query).on('click', function (event) {
                         event.stopPropagation();
-                    }).on('input keydown', $.proxy(function(event) {
+                    }).on('input keydown', $.proxy(function (event) {
                         // Cancel enter key default behaviour
                         if (event.which === 13) {
-                          event.preventDefault();
+                            event.preventDefault();
                         }
-                        
+
                         // This is useful to catch "keydown" events after the browser has updated the control.
                         clearTimeout(this.searchTimeout);
 
-                        this.searchTimeout = this.asyncFunction($.proxy(function() {
+                        this.searchTimeout = this.asyncFunction($.proxy(function () {
 
                             if (this.query !== event.target.value) {
                                 this.query = event.target.value;
 
                                 var currentGroup, currentGroupVisible;
-                                $.each($('li', this.$ul), $.proxy(function(index, element) {
+                                $.each($('li', this.$ul), $.proxy(function (index, element) {
                                     var value = $('input', element).length > 0 ? $('input', element).val() : "";
                                     var text = $('label', element).text();
 
@@ -1079,6 +1080,11 @@
                                             this.query = this.query.toLowerCase();
                                         }
 
+                                        if (this.options.enableReplaceDiacritics) {
+                                            filterCandidate = this.replaceDiacritics(filterCandidate);
+                                            this.query = this.replaceDiacritics(this.query);
+                                        }
+
                                         if (this.options.enableFullValueFiltering && this.options.filterBehavior !== 'both') {
                                             var valueToMatch = filterCandidate.trim().substring(0, this.query.length);
                                             if (this.query.indexOf(valueToMatch) > -1) {
@@ -1091,7 +1097,7 @@
 
                                         // Toggle current element (group or group item) according to showElement boolean.
                                         $(element).toggle(showElement).toggleClass('filter-hidden', !showElement);
-                                        
+
                                         // Differentiate groups and group items.
                                         if ($(element).hasClass('multiselect-group')) {
                                             // Remember group status.
@@ -1103,7 +1109,7 @@
                                             if (showElement) {
                                                 $(currentGroup).show().removeClass('filter-hidden');
                                             }
-                                            
+
                                             // Show all group items when group name satisfies filter.
                                             if (!showElement && currentGroupVisible) {
                                                 $(element).show().removeClass('filter-hidden');
@@ -1121,9 +1127,31 @@
         },
 
         /**
+         * Replace diacritics (ă,ş,ţ etc) with their "normal" form
+         *
+         * @param s
+         * @returns string
+         */
+        replaceDiacritics: function (s) {
+            var in_chrs = '¹²³áàâãäåaaaÀÁÂÃÄÅAAAÆccç©CCÇÐÐèéê?əëeeeeeÈÊË?EEEEE€gGiìíîïìiiiÌÍÎÏ?ÌIIIlLnnñNNÑòóôõöoooøÒÓÔÕÖOOOØŒr®Ršs?ßŠS?ùúûüuuuuÙÚÛÜUUUUýÿÝŸžzzŽZZ',
+                out_chrs = '123aaaaaaaaaaaaaaaaaaacccccccddeeeeeeeeeeeeeeeeeeeeeggiiiiiiiiiiiiiiiiiillnnnnnnoooooooooooooooorrrsssssssuuuuuuuuuuuuuuuuyyyyzzzzzz',
+                chars_rgx = new RegExp('[' + in_chrs + ']', 'g'),
+                transl = {}, i,
+                lookup = function (m) {
+                    return transl[m] || m;
+                };
+
+            for (i = 0; i < in_chrs.length; i++) {
+                transl[in_chrs[i]] = out_chrs[i];
+            }
+
+            return s.replace(chars_rgx, lookup);
+        },
+
+        /**
          * Unbinds the whole plugin.
          */
-        destroy: function() {
+        destroy: function () {
             this.$container.remove();
             this.$select.show();
             this.$select.data('multiselect', null);
@@ -1134,7 +1162,7 @@
          */
         refresh: function () {
             var inputs = $.map($('li input', this.$ul), $);
-            
+
             $('option', this.$select).each($.proxy(function (index, element) {
                 var $elem = $(element);
                 var value = $elem.val();
@@ -1181,15 +1209,15 @@
 
         /**
          * Select all options of the given values.
-         * 
+         *
          * If triggerOnChange is set to true, the on change event is triggered if
          * and only if one value is passed.
-         * 
+         *
          * @param {Array} selectValues
          * @param {Boolean} triggerOnChange
          */
-        select: function(selectValues, triggerOnChange) {
-            if(!$.isArray(selectValues)) {
+        select: function (selectValues, triggerOnChange) {
+            if (!$.isArray(selectValues)) {
                 selectValues = [selectValues];
             }
 
@@ -1203,14 +1231,14 @@
                 var $option = this.getOptionByValue(value);
                 var $checkbox = this.getInputByValue(value);
 
-                if($option === undefined || $checkbox === undefined) {
+                if ($option === undefined || $checkbox === undefined) {
                     continue;
                 }
-                
+
                 if (!this.options.multiple) {
                     this.deselectAll(false);
                 }
-                
+
                 if (this.options.selectedClass) {
                     $checkbox.closest('li')
                         .addClass(this.options.selectedClass);
@@ -1218,7 +1246,7 @@
 
                 $checkbox.prop('checked', true);
                 $option.prop('selected', true);
-                
+
                 if (triggerOnChange) {
                     this.options.onChange($option, true);
                 }
@@ -1239,15 +1267,15 @@
 
         /**
          * Deselects all options of the given values.
-         * 
+         *
          * If triggerOnChange is set to true, the on change event is triggered, if
          * and only if one value is passed.
-         * 
+         *
          * @param {Array} deselectValues
          * @param {Boolean} triggerOnChange
          */
-        deselect: function(deselectValues, triggerOnChange) {
-            if(!$.isArray(deselectValues)) {
+        deselect: function (deselectValues, triggerOnChange) {
+            if (!$.isArray(deselectValues)) {
                 deselectValues = [deselectValues];
             }
 
@@ -1261,7 +1289,7 @@
                 var $option = this.getOptionByValue(value);
                 var $checkbox = this.getInputByValue(value);
 
-                if($option === undefined || $checkbox === undefined) {
+                if ($option === undefined || $checkbox === undefined) {
                     continue;
                 }
 
@@ -1272,7 +1300,7 @@
 
                 $checkbox.prop('checked', false);
                 $option.prop('selected', false);
-                
+
                 if (triggerOnChange) {
                     this.options.onChange($option, false);
                 }
@@ -1281,7 +1309,7 @@
             this.updateButtonText();
             this.updateSelectAll();
         },
-        
+
         /**
          * Selects all enabled & visible options.
          *
@@ -1292,14 +1320,14 @@
          */
         selectAll: function (justVisible, triggerOnSelectAll) {
             justVisible = (this.options.enableCollapsibleOptGroups && this.options.multiple) ? false : justVisible;
-            
+
             var justVisible = typeof justVisible === 'undefined' ? true : justVisible;
             var allCheckboxes = $("li input[type='checkbox']:enabled", this.$ul);
             var visibleCheckboxes = allCheckboxes.filter(":visible");
             var allCheckboxesCount = allCheckboxes.length;
             var visibleCheckboxesCount = visibleCheckboxes.length;
-            
-            if(justVisible) {
+
+            if (justVisible) {
                 visibleCheckboxes.prop('checked', true);
                 $("li:not(.divider):not(.disabled)", this.$ul).filter(":visible").addClass(this.options.selectedClass);
             }
@@ -1307,20 +1335,20 @@
                 allCheckboxes.prop('checked', true);
                 $("li:not(.divider):not(.disabled)", this.$ul).addClass(this.options.selectedClass);
             }
-                
+
             if (allCheckboxesCount === visibleCheckboxesCount || justVisible === false) {
                 $("option:not([data-role='divider']):enabled", this.$select).prop('selected', true);
             }
             else {
-                var values = visibleCheckboxes.map(function() {
+                var values = visibleCheckboxes.map(function () {
                     return $(this).val();
                 }).get();
-                
-                $("option:enabled", this.$select).filter(function(index) {
+
+                $("option:enabled", this.$select).filter(function (index) {
                     return $.inArray($(this).val(), values) !== -1;
                 }).prop('selected', true);
             }
-            
+
             if (triggerOnSelectAll) {
                 this.options.onSelectAll();
             }
@@ -1328,27 +1356,27 @@
 
         /**
          * Deselects all options.
-         * 
+         *
          * If justVisible is true or not specified, only visible options are deselected.
-         * 
+         *
          * @param {Boolean} justVisible
          */
         deselectAll: function (justVisible) {
             justVisible = (this.options.enableCollapsibleOptGroups && this.options.multiple) ? false : justVisible;
             justVisible = typeof justVisible === 'undefined' ? true : justVisible;
-            
-            if(justVisible) {              
+
+            if (justVisible) {
                 var visibleCheckboxes = $("li input[type='checkbox']:not(:disabled)", this.$ul).filter(":visible");
                 visibleCheckboxes.prop('checked', false);
-                
-                var values = visibleCheckboxes.map(function() {
+
+                var values = visibleCheckboxes.map(function () {
                     return $(this).val();
                 }).get();
-                
-                $("option:enabled", this.$select).filter(function(index) {
+
+                $("option:enabled", this.$select).filter(function (index) {
                     return $.inArray($(this).val(), values) !== -1;
                 }).prop('selected', false);
-                
+
                 if (this.options.selectedClass) {
                     $("li:not(.divider):not(.disabled)", this.$ul).filter(":visible").removeClass(this.options.selectedClass);
                 }
@@ -1356,7 +1384,7 @@
             else {
                 $("li input[type='checkbox']:enabled", this.$ul).prop('checked', false);
                 $("option:enabled", this.$select).prop('selected', false);
-                
+
                 if (this.options.selectedClass) {
                     $("li:not(.divider):not(.disabled)", this.$ul).removeClass(this.options.selectedClass);
                 }
@@ -1365,10 +1393,10 @@
 
         /**
          * Rebuild the plugin.
-         * 
+         *
          * Rebuilds the dropdown, the filter and the select all option.
          */
-        rebuild: function() {
+        rebuild: function () {
             this.$ul.html('');
 
             // Important to distinguish between radios and checkboxes.
@@ -1380,14 +1408,14 @@
 
             this.updateButtonText();
             this.updateSelectAll(true);
-            
+
             if (this.options.disableIfEmpty && $('option', this.$select).length <= 0) {
                 this.disable();
             }
             else {
                 this.enable();
             }
-            
+
             if (this.options.dropRight) {
                 this.$ul.addClass('pull-right');
             }
@@ -1396,23 +1424,23 @@
         /**
          * The provided data will be used to build the dropdown.
          */
-        dataprovider: function(dataprovider) {
-            
+        dataprovider: function (dataprovider) {
+
             var groupCounter = 0;
             var $select = this.$select.empty();
-            
+
             $.each(dataprovider, function (index, option) {
                 var $tag;
-                
+
                 if ($.isArray(option.children)) { // create optiongroup tag
                     groupCounter++;
-                    
+
                     $tag = $('<optgroup/>').attr({
                         label: option.label || 'Group ' + groupCounter,
                         disabled: !!option.disabled
                     });
-                    
-                    forEach(option.children, function(subOption) { // add children option tags
+
+                    forEach(option.children, function (subOption) { // add children option tags
                         $tag.append($('<option/>').attr({
                             value: subOption.value,
                             label: subOption.label || subOption.value,
@@ -1433,17 +1461,17 @@
                     });
                     $tag.text(option.label || option.value);
                 }
-                
+
                 $select.append($tag);
             });
-            
+
             this.rebuild();
         },
 
         /**
          * Enable the multiselect.
          */
-        enable: function() {
+        enable: function () {
             this.$select.prop('disabled', false);
             this.$button.prop('disabled', false)
                 .removeClass('disabled');
@@ -1452,7 +1480,7 @@
         /**
          * Disable the multiselect.
          */
-        disable: function() {
+        disable: function () {
             this.$select.prop('disabled', true);
             this.$button.prop('disabled', true)
                 .addClass('disabled');
@@ -1463,7 +1491,7 @@
          *
          * @param {Array} options
          */
-        setOptions: function(options) {
+        setOptions: function (options) {
             this.options = this.mergeOptions(options);
         },
 
@@ -1473,7 +1501,7 @@
          * @param {Array} options
          * @returns {Array}
          */
-        mergeOptions: function(options) {
+        mergeOptions: function (options) {
             return $.extend(true, {}, this.defaults, this.options, options);
         },
 
@@ -1482,21 +1510,21 @@
          *
          * @returns {Boolean}
          */
-        hasSelectAll: function() {
+        hasSelectAll: function () {
             return $('li.multiselect-all', this.$ul).length > 0;
         },
 
         /**
          * Updates the select all checkbox based on the currently displayed and selected checkboxes.
          */
-        updateSelectAll: function(notTriggerOnSelectAll) {
+        updateSelectAll: function (notTriggerOnSelectAll) {
             if (this.hasSelectAll()) {
                 var allBoxes = $("li:not(.multiselect-item):not(.filter-hidden) input:enabled", this.$ul);
                 var allBoxesLength = allBoxes.length;
                 var checkedBoxesLength = allBoxes.filter(":checked").length;
-                var selectAllLi  = $("li.multiselect-all", this.$ul);
+                var selectAllLi = $("li.multiselect-all", this.$ul);
                 var selectAllInput = selectAllLi.find("input");
-                
+
                 if (checkedBoxesLength > 0 && checkedBoxesLength === allBoxesLength) {
                     selectAllInput.prop("checked", true);
                     selectAllLi.addClass(this.options.selectedClass);
@@ -1517,9 +1545,9 @@
         /**
          * Update the button text and its title based on the currently selected options.
          */
-        updateButtonText: function() {
+        updateButtonText: function () {
             var options = this.getSelected();
-            
+
             // First update the displayed button text.
             if (this.options.enableHTML) {
                 $('.multiselect .multiselect-selected-text', this.$container).html(this.options.buttonText(options, this.$select));
@@ -1527,7 +1555,7 @@
             else {
                 $('.multiselect .multiselect-selected-text', this.$container).text(this.options.buttonText(options, this.$select));
             }
-            
+
             // Now update the title attribute of the button.
             $('.multiselect', this.$container).attr('title', this.options.buttonTitle(options, this.$select));
         },
@@ -1537,7 +1565,7 @@
          *
          * @returns {jQUery}
          */
-        getSelected: function() {
+        getSelected: function () {
             return $('option', this.$select).filter(":selected");
         },
 
@@ -1582,25 +1610,25 @@
         /**
          * Used for knockout integration.
          */
-        updateOriginalOptions: function() {
+        updateOriginalOptions: function () {
             this.originalOptions = this.$select.clone()[0].options;
         },
 
-        asyncFunction: function(callback, timeout, self) {
+        asyncFunction: function (callback, timeout, self) {
             var args = Array.prototype.slice.call(arguments, 3);
-            return setTimeout(function() {
+            return setTimeout(function () {
                 callback.apply(self || window, args);
             }, timeout);
         },
 
-        setAllSelectedText: function(allSelectedText) {
+        setAllSelectedText: function (allSelectedText) {
             this.options.allSelectedText = allSelectedText;
             this.updateButtonText();
         }
     };
 
-    $.fn.multiselect = function(option, parameter, extraOptions) {
-        return this.each(function() {
+    $.fn.multiselect = function (option, parameter, extraOptions) {
+        return this.each(function () {
             var data = $(this).data('multiselect');
             var options = typeof option === 'object' && option;
 
@@ -1613,7 +1641,7 @@
             // Call multiselect method.
             if (typeof option === 'string') {
                 data[option](parameter, extraOptions);
-                
+
                 if (option === 'destroy') {
                     $(this).data('multiselect', false);
                 }
@@ -1623,7 +1651,7 @@
 
     $.fn.multiselect.Constructor = Multiselect;
 
-    $(function() {
+    $(function () {
         $("select[data-role=multiselect]").multiselect();
     });
 

--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1,23 +1,23 @@
 /**
  * Bootstrap Multiselect (https://github.com/davidstutz/bootstrap-multiselect)
- *
+ * 
  * Apache License, Version 2.0:
  * Copyright (c) 2012 - 2015 David Stutz
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a
  * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations
  * under the License.
- *
+ * 
  * BSD 3-Clause License:
  * Copyright (c) 2012 - 2015 David Stutz
  * All rights reserved.
- *
+ * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *    - Redistributions of source code must retain the above copyright notice,
@@ -28,7 +28,7 @@
  *    - Neither the name of David Stutz nor the names of its contributors may be
  *      used to endorse or promote products derived from this software without
  *      specific prior written permission.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
  * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
@@ -48,7 +48,7 @@
         ko.bindingHandlers.multiselect = {
             after: ['options', 'value', 'selectedOptions', 'enable', 'disable'],
 
-            init: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
+            init: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
                 var $element = $(element);
                 var config = ko.toJS(valueAccessor());
 
@@ -58,9 +58,9 @@
                     var options = allBindings.get('options');
                     if (ko.isObservable(options)) {
                         ko.computed({
-                            read: function () {
+                            read: function() {
                                 options();
-                                setTimeout(function () {
+                                setTimeout(function() {
                                     var ms = $element.data('multiselect');
                                     if (ms)
                                         ms.updateOriginalOptions();//Not sure how beneficial this is.
@@ -79,14 +79,14 @@
                     var value = allBindings.get('value');
                     if (ko.isObservable(value)) {
                         ko.computed({
-                            read: function () {
+                            read: function() {
                                 value();
-                                setTimeout(function () {
+                                setTimeout(function() {
                                     $element.multiselect('refresh');
                                 }, 1);
                             },
                             disposeWhenNodeIsRemoved: element
-                        }).extend({rateLimit: 100, notifyWhenChangesStop: true});
+                        }).extend({ rateLimit: 100, notifyWhenChangesStop: true });
                     }
                 }
 
@@ -96,14 +96,14 @@
                     var selectedOptions = allBindings.get('selectedOptions');
                     if (ko.isObservable(selectedOptions)) {
                         ko.computed({
-                            read: function () {
+                            read: function() {
                                 selectedOptions();
-                                setTimeout(function () {
+                                setTimeout(function() {
                                     $element.multiselect('refresh');
                                 }, 1);
                             },
                             disposeWhenNodeIsRemoved: element
-                        }).extend({rateLimit: 100, notifyWhenChangesStop: true});
+                        }).extend({ rateLimit: 100, notifyWhenChangesStop: true });
                     }
                 }
 
@@ -124,7 +124,7 @@
                                 setEnabled(enable());
                             },
                             disposeWhenNodeIsRemoved: element
-                        }).extend({rateLimit: 100, notifyWhenChangesStop: true});
+                        }).extend({ rateLimit: 100, notifyWhenChangesStop: true });
                     } else {
                         setEnabled(enable);
                     }
@@ -138,18 +138,18 @@
                                 setEnabled(!disable());
                             },
                             disposeWhenNodeIsRemoved: element
-                        }).extend({rateLimit: 100, notifyWhenChangesStop: true});
+                        }).extend({ rateLimit: 100, notifyWhenChangesStop: true });
                     } else {
                         setEnabled(!disable);
                     }
                 }
 
-                ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
+                ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
                     $element.multiselect('destroy');
                 });
             },
 
-            update: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
+            update: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
                 var $element = $(element);
                 var config = ko.toJS(valueAccessor());
 
@@ -175,12 +175,12 @@
     function Multiselect(select, options) {
 
         this.$select = $(select);
-
+        
         // Placeholder via data attributes
         if (this.$select.attr("data-placeholder")) {
             options.nonSelectedText = this.$select.data("placeholder");
         }
-
+        
         this.options = this.mergeOptions($.extend({}, options, this.$select.data()));
 
         // Initialization.
@@ -197,7 +197,7 @@
         this.options.onDropdownShown = $.proxy(this.options.onDropdownShown, this);
         this.options.onDropdownHidden = $.proxy(this.options.onDropdownHidden, this);
         this.options.onInitialized = $.proxy(this.options.onInitialized, this);
-
+        
         // Build select all if enabled.
         this.buildContainer();
         this.buildButton();
@@ -212,7 +212,7 @@
         if (this.options.disableIfEmpty && $('option', this.$select).length <= 0) {
             this.disable();
         }
-
+        
         this.$select.hide().after(this.$container);
         this.options.onInitialized(this.$select, this.$container);
     }
@@ -224,25 +224,25 @@
              * Default text function will either print 'None selected' in case no
              * option is selected or a list of the selected options up to a length
              * of 3 selected options.
-             *
+             * 
              * @param {jQuery} options
              * @param {jQuery} select
              * @returns {String}
              */
-            buttonText: function (options, select) {
-                if (this.disabledText.length > 0
-                    && (this.disableIfEmpty || select.prop('disabled'))
-                    && options.length == 0) {
-
+            buttonText: function(options, select) {
+                if (this.disabledText.length > 0 
+                        && (this.disableIfEmpty || select.prop('disabled')) 
+                        && options.length == 0) {
+                    
                     return this.disabledText;
                 }
                 else if (options.length === 0) {
                     return this.nonSelectedText;
                 }
-                else if (this.allSelectedText
-                    && options.length === $('option', $(select)).length
-                    && $('option', $(select)).length !== 1
-                    && this.multiple) {
+                else if (this.allSelectedText 
+                        && options.length === $('option', $(select)).length 
+                        && $('option', $(select)).length !== 1 
+                        && this.multiple) {
 
                     if (this.selectAllNumber) {
                         return this.allSelectedText + ' (' + options.length + ')';
@@ -257,30 +257,30 @@
                 else {
                     var selected = '';
                     var delimiter = this.delimiterText;
-
-                    options.each(function () {
+                    
+                    options.each(function() {
                         var label = ($(this).attr('label') !== undefined) ? $(this).attr('label') : $(this).text();
                         selected += label + delimiter;
                     });
-
+                    
                     return selected.substr(0, selected.length - 2);
                 }
             },
             /**
              * Updates the title of the button similar to the buttonText function.
-             *
+             * 
              * @param {jQuery} options
              * @param {jQuery} select
              * @returns {@exp;selected@call;substr}
              */
-            buttonTitle: function (options, select) {
+            buttonTitle: function(options, select) {
                 if (options.length === 0) {
                     return this.nonSelectedText;
                 }
                 else {
                     var selected = '';
                     var delimiter = this.delimiterText;
-
+                    
                     options.each(function () {
                         var label = ($(this).attr('label') !== undefined) ? $(this).attr('label') : $(this).text();
                         selected += label + delimiter;
@@ -294,7 +294,7 @@
              * @param {jQuery} element
              * @returns {String}
              */
-            optionLabel: function (element) {
+            optionLabel: function(element){
                 return $(element).attr('label') || $(element).text();
             },
             /**
@@ -303,18 +303,18 @@
              * @param {jQuery} element
              * @returns {String}
              */
-            optionClass: function (element) {
+            optionClass: function(element) {
                 return $(element).attr('class') || '';
             },
             /**
              * Triggered on change of the multiselect.
-             *
+             * 
              * Not triggered when selecting/deselecting options manually.
-             *
+             * 
              * @param {jQuery} option
              * @param {Boolean} checked
              */
-            onChange: function (option, checked) {
+            onChange : function(option, checked) {
 
             },
             /**
@@ -322,7 +322,7 @@
              *
              * @param {jQuery} event
              */
-            onDropdownShow: function (event) {
+            onDropdownShow: function(event) {
 
             },
             /**
@@ -330,30 +330,30 @@
              *
              * @param {jQuery} event
              */
-            onDropdownHide: function (event) {
+            onDropdownHide: function(event) {
 
             },
             /**
              * Triggered after the dropdown is shown.
-             *
+             * 
              * @param {jQuery} event
              */
-            onDropdownShown: function (event) {
-
+            onDropdownShown: function(event) {
+                
             },
             /**
              * Triggered after the dropdown is hidden.
-             *
+             * 
              * @param {jQuery} event
              */
-            onDropdownHidden: function (event) {
-
+            onDropdownHidden: function(event) {
+                
             },
             /**
              * Triggered on select all.
              */
-            onSelectAll: function (checked) {
-
+            onSelectAll: function(checked) {
+                
             },
             /**
              * Triggered after initializing.
@@ -361,7 +361,7 @@
              * @param {jQuery} $select
              * @param {jQuery} $container
              */
-            onInitialized: function ($select, $container) {
+            onInitialized: function($select, $container) {
 
             },
             enableHTML: false,
@@ -417,7 +417,7 @@
         /**
          * Builds the container of the multiselect.
          */
-        buildContainer: function () {
+        buildContainer: function() {
             this.$container = $(this.options.buttonContainer);
             this.$container.on('show.bs.dropdown', this.options.onDropdownShow);
             this.$container.on('hide.bs.dropdown', this.options.onDropdownHide);
@@ -428,7 +428,7 @@
         /**
          * Builds the button of the multiselect.
          */
-        buildButton: function () {
+        buildButton: function() {
             this.$button = $(this.options.templates.button).addClass(this.options.buttonClass);
             if (this.$select.attr('class') && this.options.inheritClass) {
                 this.$button.addClass(this.$select.attr('class'));
@@ -444,9 +444,9 @@
             // Manually add button width if set.
             if (this.options.buttonWidth && this.options.buttonWidth !== 'auto') {
                 this.$button.css({
-                    'width': this.options.buttonWidth,
-                    'overflow': 'hidden',
-                    'text-overflow': 'ellipsis'
+                    'width' : this.options.buttonWidth,
+                    'overflow' : 'hidden',
+                    'text-overflow' : 'ellipsis'
                 });
                 this.$container.css({
                     'width': this.options.buttonWidth
@@ -465,7 +465,7 @@
         /**
          * Builds the ul representing the dropdown menu.
          */
-        buildDropdown: function () {
+        buildDropdown: function() {
 
             // Build ul.
             this.$ul = $(this.options.templates.ul);
@@ -483,12 +483,12 @@
                     'overflow-x': 'hidden'
                 });
             }
-
+            
             if (this.options.dropUp) {
-
-                var height = Math.min(this.options.maxHeight, $('option[data-role!="divider"]', this.$select).length * 26 + $('option[data-role="divider"]', this.$select).length * 19 + (this.options.includeSelectAllOption ? 26 : 0) + (this.options.enableFiltering || this.options.enableCaseInsensitiveFiltering ? 44 : 0));
+                
+                var height = Math.min(this.options.maxHeight, $('option[data-role!="divider"]', this.$select).length*26 + $('option[data-role="divider"]', this.$select).length*19 + (this.options.includeSelectAllOption ? 26 : 0) + (this.options.enableFiltering || this.options.enableCaseInsensitiveFiltering ? 44 : 0));
                 var moveCalc = height + 34;
-
+                
                 this.$ul.css({
                     'max-height': height + 'px',
                     'overflow-y': 'auto',
@@ -496,24 +496,24 @@
                     'margin-top': "-" + moveCalc + 'px'
                 });
             }
-
+            
             this.$container.append(this.$ul);
         },
 
         /**
          * Build the dropdown options and binds all nessecary events.
-         *
+         * 
          * Uses createDivider and createOptionValue to create the necessary options.
          */
-        buildDropdownOptions: function () {
+        buildDropdownOptions: function() {
 
-            this.$select.children().each($.proxy(function (index, element) {
+            this.$select.children().each($.proxy(function(index, element) {
 
                 var $element = $(element);
                 // Support optgroups and options without a group simultaneously.
                 var tag = $element.prop('tagName')
                     .toLowerCase();
-
+            
                 if ($element.prop('value') === this.options.selectAllValue) {
                     return;
                 }
@@ -536,7 +536,7 @@
             }, this));
 
             // Bind the change event on the dropdown elements.
-            $('li input', this.$ul).on('change', $.proxy(function (event) {
+            $('li input', this.$ul).on('change', $.proxy(function(event) {
                 var $target = $(event.target);
 
                 var checked = $target.prop('checked') || false;
@@ -598,7 +598,7 @@
                         // Unselect option.
                         $option.prop('selected', false);
                     }
-
+                    
                     // To prevent select all from firing onChange: #575
                     this.options.onChange($option, checked);
                 }
@@ -608,25 +608,25 @@
                 this.updateButtonText();
                 this.updateSelectAll();
 
-                if (this.options.preventInputChangeEvent) {
+                if(this.options.preventInputChangeEvent) {
                     return false;
                 }
             }, this));
 
-            $('li a', this.$ul).on('mousedown', function (e) {
+            $('li a', this.$ul).on('mousedown', function(e) {
                 if (e.shiftKey) {
                     // Prevent selecting text by Shift+click
                     return false;
                 }
             });
-
-            $('li a', this.$ul).on('touchstart click', $.proxy(function (event) {
+        
+            $('li a', this.$ul).on('touchstart click', $.proxy(function(event) {
                 event.stopPropagation();
 
                 var $target = $(event.target);
-
+                
                 if (event.shiftKey && this.options.multiple) {
-                    if ($target.is("label")) { // Handles checkbox selection manually (see https://github.com/davidstutz/bootstrap-multiselect/issues/431)
+                    if($target.is("label")){ // Handles checkbox selection manually (see https://github.com/davidstutz/bootstrap-multiselect/issues/431)
                         event.preventDefault();
                         $target = $target.find("input");
                         $target.prop("checked", !$target.prop("checked"));
@@ -636,41 +636,41 @@
                     if (this.lastToggledInput !== null && this.lastToggledInput !== $target) { // Make sure we actually have a range
                         var from = $target.closest("li").index();
                         var to = this.lastToggledInput.closest("li").index();
-
+                        
                         if (from > to) { // Swap the indices
                             var tmp = to;
                             to = from;
                             from = tmp;
                         }
-
+                        
                         // Make sure we grab all elements since slice excludes the last index
                         ++to;
-
+                        
                         // Change the checkboxes and underlying options
                         var range = this.$ul.find("li").slice(from, to).find("input");
-
+                        
                         range.prop('checked', checked);
-
+                        
                         if (this.options.selectedClass) {
                             range.closest('li')
                                 .toggleClass(this.options.selectedClass, checked);
                         }
-
+                        
                         for (var i = 0, j = range.length; i < j; i++) {
                             var $checkbox = $(range[i]);
 
                             var $option = this.getOptionByValue($checkbox.val());
 
                             $option.prop('selected', checked);
-                        }
+                        }                   
                     }
-
+                    
                     // Trigger the select "change" event
                     $target.trigger("change");
                 }
-
+                
                 // Remembers last clicked option
-                if ($target.is("input") && !$target.closest("li").is(".multiselect-item")) {
+                if($target.is("input") && !$target.closest("li").is(".multiselect-item")){
                     this.lastToggledInput = $target;
                 }
 
@@ -678,7 +678,7 @@
             }, this));
 
             // Keyboard support.
-            this.$container.off('keydown.multiselect').on('keydown.multiselect', $.proxy(function (event) {
+            this.$container.off('keydown.multiselect').on('keydown.multiselect', $.proxy(function(event) {
                 if ($('input[type="text"]', this.$container).is(':focus')) {
                     return;
                 }
@@ -722,8 +722,8 @@
                 }
             }, this));
 
-            if (this.options.enableClickableOptGroups && this.options.multiple) {
-                $('li.multiselect-group', this.$ul).on('click', $.proxy(function (event) {
+            if(this.options.enableClickableOptGroups && this.options.multiple) {
+                $('li.multiselect-group', this.$ul).on('click', $.proxy(function(event) {
                     event.stopPropagation();
                     console.log('test');
                     var group = $(event.target).parent();
@@ -736,8 +736,8 @@
                     var allChecked = true;
                     var optionInputs = $visibleOptions.find('input');
                     var values = [];
-
-                    optionInputs.each(function () {
+                    
+                    optionInputs.each(function() {
                         allChecked = allChecked && $(this).prop('checked');
                         values.push($(this).val());
                     });
@@ -748,83 +748,83 @@
                     else {
                         this.deselect(values, false);
                     }
-
+                    
                     this.options.onChange(optionInputs, !allChecked);
-                }, this));
+               }, this));
             }
 
             if (this.options.enableCollapsibleOptGroups && this.options.multiple) {
                 $("li.multiselect-group input", this.$ul).off();
-                $("li.multiselect-group", this.$ul).siblings().not("li.multiselect-group, li.multiselect-all", this.$ul).each(function () {
+                $("li.multiselect-group", this.$ul).siblings().not("li.multiselect-group, li.multiselect-all", this.$ul).each( function () {
                     $(this).toggleClass('hidden', true);
                 });
-
-                $("li.multiselect-group", this.$ul).on("click", $.proxy(function (group) {
+                
+                $("li.multiselect-group", this.$ul).on("click", $.proxy(function(group) {
                     group.stopPropagation();
                 }, this));
-
-                $("li.multiselect-group > a > b", this.$ul).on("click", $.proxy(function (t) {
+                
+                $("li.multiselect-group > a > b", this.$ul).on("click", $.proxy(function(t) {
                     t.stopPropagation();
                     var n = $(t.target).closest('li');
                     var r = n.nextUntil("li.multiselect-group");
                     var i = true;
-
-                    r.each(function () {
+                    
+                    r.each(function() {
                         i = i && $(this).hasClass('hidden');
                     });
-
+                    
                     r.toggleClass('hidden', !i);
                 }, this));
-
-                $("li.multiselect-group > a > input", this.$ul).on("change", $.proxy(function (t) {
+                
+                $("li.multiselect-group > a > input", this.$ul).on("change", $.proxy(function(t) {
                     t.stopPropagation();
                     var n = $(t.target).closest('li');
                     var r = n.nextUntil("li.multiselect-group", ':not(.disabled)');
                     var s = r.find("input");
-
+                    
                     var i = true;
-                    s.each(function () {
+                    s.each(function() {
                         i = i && $(this).prop("checked");
                     });
-
+                    
                     s.prop("checked", !i).trigger("change");
                 }, this));
-
+                
                 // Set the initial selection state of the groups.
-                $('li.multiselect-group', this.$ul).each(function () {
+                $('li.multiselect-group', this.$ul).each(function() {
                     var r = $(this).nextUntil("li.multiselect-group", ':not(.disabled)');
                     var s = r.find("input");
-
+                    
                     var i = true;
-                    s.each(function () {
+                    s.each(function() {
                         i = i && $(this).prop("checked");
                     });
-
+                    
                     $(this).find('input').prop("checked", i);
                 });
-
+                
                 // Update the group checkbox based on new selections among the
                 // corresponding children.
-                $("li input", this.$ul).on("change", $.proxy(function (t) {
+                $("li input", this.$ul).on("change", $.proxy(function(t) {
                     t.stopPropagation();
                     var n = $(t.target).closest('li');
                     var r1 = n.prevUntil("li.multiselect-group", ':not(.disabled)');
                     var r2 = n.nextUntil("li.multiselect-group", ':not(.disabled)');
                     var s1 = r1.find("input");
                     var s2 = r2.find("input");
-
+                    
                     var i = $(t.target).prop('checked');
-                    s1.each(function () {
+                    s1.each(function() {
                         i = i && $(this).prop("checked");
                     });
-
-                    s2.each(function () {
+                    
+                    s2.each(function() {
                         i = i && $(this).prop("checked");
                     });
-
+                    
                     n.prevAll('.multiselect-group').find('input').prop('checked', i);
                 }, this));
-
+                
                 $("li.multiselect-all", this.$ul).css('background', '#f3f3f3').css('border-bottom', '1px solid #eaeaea');
                 $("li.multiselect-group > a, li.multiselect-all > a > label.checkbox", this.$ul).css('padding', '3px 20px 3px 35px');
                 $("li.multiselect-group > a > input", this.$ul).css('margin', '4px 0px 5px -20px');
@@ -836,7 +836,7 @@
          *
          * @param {jQuery} element
          */
-        createOptionValue: function (element) {
+        createOptionValue: function(element) {
             var $element = $(element);
             if ($element.is(':selected')) {
                 $element.prop('selected', true);
@@ -859,7 +859,7 @@
             else {
                 $label.text(" " + label);
             }
-
+        
             var $checkbox = $('<input/>').attr('type', inputType);
 
             if (this.options.checkboxName) {
@@ -902,7 +902,7 @@
          *
          * @param {jQuery} element
          */
-        createDivider: function (element) {
+        createDivider: function(element) {
             var $divider = $(this.options.templates.divider);
             this.$ul.append($divider);
         },
@@ -912,7 +912,7 @@
          *
          * @param {jQuery} group
          */
-        createOptgroup: function (group) {
+        createOptgroup: function(group) {            
             if (this.options.enableCollapsibleOptGroups && this.options.multiple) {
                 var label = $(group).attr("label");
                 var value = $(group).attr("value");
@@ -925,7 +925,7 @@
                 if ($(group).is(":disabled")) {
                     r.addClass("disabled")
                 }
-                $("option", group).each($.proxy(function ($, group) {
+                $("option", group).each($.proxy(function($, group) {
                     this.createOptionValue(group)
                 }, this))
             }
@@ -953,7 +953,7 @@
                 }
 
                 // Add the options of the group.
-                $('option', group).each($.proxy(function (index, element) {
+                $('option', group).each($.proxy(function(index, element) {
                     this.createOptionValue(element);
                 }, this));
             }
@@ -961,18 +961,18 @@
 
         /**
          * Build the select all.
-         *
+         * 
          * Checks if a select all has already been created.
          */
-        buildSelectAll: function () {
+        buildSelectAll: function() {
             if (typeof this.options.selectAllValue === 'number') {
                 this.options.selectAllValue = this.options.selectAllValue.toString();
             }
-
+            
             var alreadyHasSelectAll = this.hasSelectAll();
 
             if (!alreadyHasSelectAll && this.options.includeSelectAllOption && this.options.multiple
-                && $('option', this.$select).length > this.options.includeSelectAllIfMoreThan) {
+                    && $('option', this.$select).length > this.options.includeSelectAllIfMoreThan) {
 
                 // Check whether to add a divider after the select all.
                 if (this.options.includeSelectAllDivider) {
@@ -981,21 +981,21 @@
 
                 var $li = $(this.options.templates.li);
                 $('label', $li).addClass("checkbox");
-
+                
                 if (this.options.enableHTML) {
                     $('label', $li).html(" " + this.options.selectAllText);
                 }
                 else {
                     $('label', $li).text(" " + this.options.selectAllText);
                 }
-
+                
                 if (this.options.selectAllName) {
                     $('label', $li).prepend('<input type="checkbox" name="' + this.options.selectAllName + '" />');
                 }
                 else {
                     $('label', $li).prepend('<input type="checkbox" />');
                 }
-
+                
                 var $checkbox = $('input', $li);
                 $checkbox.val(this.options.selectAllValue);
 
@@ -1012,7 +1012,7 @@
         /**
          * Builds the filter.
          */
-        buildFilter: function () {
+        buildFilter: function() {
 
             // Build filter if filtering OR case insensitive filtering is enabled and the number of options exceeds (or equals) enableFilterLength.
             if (this.options.enableFiltering || this.options.enableCaseInsensitiveFiltering) {
@@ -1022,11 +1022,11 @@
 
                     this.$filter = $(this.options.templates.filter);
                     $('input', this.$filter).attr('placeholder', this.options.filterPlaceholder);
-
+                    
                     // Adds optional filter clear button
-                    if (this.options.includeFilterClearBtn) {
+                    if(this.options.includeFilterClearBtn){
                         var clearBtn = $(this.options.templates.filterClearBtn);
-                        clearBtn.on('click', $.proxy(function (event) {
+                        clearBtn.on('click', $.proxy(function(event){
                             clearTimeout(this.searchTimeout);
                             this.$filter.find('.multiselect-search').val('');
                             $('li', this.$ul).show().removeClass("filter-hidden");
@@ -1034,27 +1034,27 @@
                         }, this));
                         this.$filter.find('.input-group').append(clearBtn);
                     }
-
+                    
                     this.$ul.prepend(this.$filter);
 
-                    this.$filter.val(this.query).on('click', function (event) {
+                    this.$filter.val(this.query).on('click', function(event) {
                         event.stopPropagation();
-                    }).on('input keydown', $.proxy(function (event) {
+                    }).on('input keydown', $.proxy(function(event) {
                         // Cancel enter key default behaviour
                         if (event.which === 13) {
-                            event.preventDefault();
+                          event.preventDefault();
                         }
-
+                        
                         // This is useful to catch "keydown" events after the browser has updated the control.
                         clearTimeout(this.searchTimeout);
 
-                        this.searchTimeout = this.asyncFunction($.proxy(function () {
+                        this.searchTimeout = this.asyncFunction($.proxy(function() {
 
                             if (this.query !== event.target.value) {
                                 this.query = event.target.value;
 
                                 var currentGroup, currentGroupVisible;
-                                $.each($('li', this.$ul), $.proxy(function (index, element) {
+                                $.each($('li', this.$ul), $.proxy(function(index, element) {
                                     var value = $('input', element).length > 0 ? $('input', element).val() : "";
                                     var text = $('label', element).text();
 
@@ -1097,7 +1097,7 @@
 
                                         // Toggle current element (group or group item) according to showElement boolean.
                                         $(element).toggle(showElement).toggleClass('filter-hidden', !showElement);
-
+                                        
                                         // Differentiate groups and group items.
                                         if ($(element).hasClass('multiselect-group')) {
                                             // Remember group status.
@@ -1109,7 +1109,7 @@
                                             if (showElement) {
                                                 $(currentGroup).show().removeClass('filter-hidden');
                                             }
-
+                                            
                                             // Show all group items when group name satisfies filter.
                                             if (!showElement && currentGroupVisible) {
                                                 $(element).show().removeClass('filter-hidden');
@@ -1151,7 +1151,7 @@
         /**
          * Unbinds the whole plugin.
          */
-        destroy: function () {
+        destroy: function() {
             this.$container.remove();
             this.$select.show();
             this.$select.data('multiselect', null);
@@ -1162,7 +1162,7 @@
          */
         refresh: function () {
             var inputs = $.map($('li input', this.$ul), $);
-
+            
             $('option', this.$select).each($.proxy(function (index, element) {
                 var $elem = $(element);
                 var value = $elem.val();
@@ -1209,15 +1209,15 @@
 
         /**
          * Select all options of the given values.
-         *
+         * 
          * If triggerOnChange is set to true, the on change event is triggered if
          * and only if one value is passed.
-         *
+         * 
          * @param {Array} selectValues
          * @param {Boolean} triggerOnChange
          */
-        select: function (selectValues, triggerOnChange) {
-            if (!$.isArray(selectValues)) {
+        select: function(selectValues, triggerOnChange) {
+            if(!$.isArray(selectValues)) {
                 selectValues = [selectValues];
             }
 
@@ -1231,14 +1231,14 @@
                 var $option = this.getOptionByValue(value);
                 var $checkbox = this.getInputByValue(value);
 
-                if ($option === undefined || $checkbox === undefined) {
+                if($option === undefined || $checkbox === undefined) {
                     continue;
                 }
-
+                
                 if (!this.options.multiple) {
                     this.deselectAll(false);
                 }
-
+                
                 if (this.options.selectedClass) {
                     $checkbox.closest('li')
                         .addClass(this.options.selectedClass);
@@ -1246,7 +1246,7 @@
 
                 $checkbox.prop('checked', true);
                 $option.prop('selected', true);
-
+                
                 if (triggerOnChange) {
                     this.options.onChange($option, true);
                 }
@@ -1267,15 +1267,15 @@
 
         /**
          * Deselects all options of the given values.
-         *
+         * 
          * If triggerOnChange is set to true, the on change event is triggered, if
          * and only if one value is passed.
-         *
+         * 
          * @param {Array} deselectValues
          * @param {Boolean} triggerOnChange
          */
-        deselect: function (deselectValues, triggerOnChange) {
-            if (!$.isArray(deselectValues)) {
+        deselect: function(deselectValues, triggerOnChange) {
+            if(!$.isArray(deselectValues)) {
                 deselectValues = [deselectValues];
             }
 
@@ -1289,7 +1289,7 @@
                 var $option = this.getOptionByValue(value);
                 var $checkbox = this.getInputByValue(value);
 
-                if ($option === undefined || $checkbox === undefined) {
+                if($option === undefined || $checkbox === undefined) {
                     continue;
                 }
 
@@ -1300,7 +1300,7 @@
 
                 $checkbox.prop('checked', false);
                 $option.prop('selected', false);
-
+                
                 if (triggerOnChange) {
                     this.options.onChange($option, false);
                 }
@@ -1309,7 +1309,7 @@
             this.updateButtonText();
             this.updateSelectAll();
         },
-
+        
         /**
          * Selects all enabled & visible options.
          *
@@ -1320,14 +1320,14 @@
          */
         selectAll: function (justVisible, triggerOnSelectAll) {
             justVisible = (this.options.enableCollapsibleOptGroups && this.options.multiple) ? false : justVisible;
-
+            
             var justVisible = typeof justVisible === 'undefined' ? true : justVisible;
             var allCheckboxes = $("li input[type='checkbox']:enabled", this.$ul);
             var visibleCheckboxes = allCheckboxes.filter(":visible");
             var allCheckboxesCount = allCheckboxes.length;
             var visibleCheckboxesCount = visibleCheckboxes.length;
-
-            if (justVisible) {
+            
+            if(justVisible) {
                 visibleCheckboxes.prop('checked', true);
                 $("li:not(.divider):not(.disabled)", this.$ul).filter(":visible").addClass(this.options.selectedClass);
             }
@@ -1335,20 +1335,20 @@
                 allCheckboxes.prop('checked', true);
                 $("li:not(.divider):not(.disabled)", this.$ul).addClass(this.options.selectedClass);
             }
-
+                
             if (allCheckboxesCount === visibleCheckboxesCount || justVisible === false) {
                 $("option:not([data-role='divider']):enabled", this.$select).prop('selected', true);
             }
             else {
-                var values = visibleCheckboxes.map(function () {
+                var values = visibleCheckboxes.map(function() {
                     return $(this).val();
                 }).get();
-
-                $("option:enabled", this.$select).filter(function (index) {
+                
+                $("option:enabled", this.$select).filter(function(index) {
                     return $.inArray($(this).val(), values) !== -1;
                 }).prop('selected', true);
             }
-
+            
             if (triggerOnSelectAll) {
                 this.options.onSelectAll();
             }
@@ -1356,27 +1356,27 @@
 
         /**
          * Deselects all options.
-         *
+         * 
          * If justVisible is true or not specified, only visible options are deselected.
-         *
+         * 
          * @param {Boolean} justVisible
          */
         deselectAll: function (justVisible) {
             justVisible = (this.options.enableCollapsibleOptGroups && this.options.multiple) ? false : justVisible;
             justVisible = typeof justVisible === 'undefined' ? true : justVisible;
-
-            if (justVisible) {
+            
+            if(justVisible) {              
                 var visibleCheckboxes = $("li input[type='checkbox']:not(:disabled)", this.$ul).filter(":visible");
                 visibleCheckboxes.prop('checked', false);
-
-                var values = visibleCheckboxes.map(function () {
+                
+                var values = visibleCheckboxes.map(function() {
                     return $(this).val();
                 }).get();
-
-                $("option:enabled", this.$select).filter(function (index) {
+                
+                $("option:enabled", this.$select).filter(function(index) {
                     return $.inArray($(this).val(), values) !== -1;
                 }).prop('selected', false);
-
+                
                 if (this.options.selectedClass) {
                     $("li:not(.divider):not(.disabled)", this.$ul).filter(":visible").removeClass(this.options.selectedClass);
                 }
@@ -1384,7 +1384,7 @@
             else {
                 $("li input[type='checkbox']:enabled", this.$ul).prop('checked', false);
                 $("option:enabled", this.$select).prop('selected', false);
-
+                
                 if (this.options.selectedClass) {
                     $("li:not(.divider):not(.disabled)", this.$ul).removeClass(this.options.selectedClass);
                 }
@@ -1393,10 +1393,10 @@
 
         /**
          * Rebuild the plugin.
-         *
+         * 
          * Rebuilds the dropdown, the filter and the select all option.
          */
-        rebuild: function () {
+        rebuild: function() {
             this.$ul.html('');
 
             // Important to distinguish between radios and checkboxes.
@@ -1408,14 +1408,14 @@
 
             this.updateButtonText();
             this.updateSelectAll(true);
-
+            
             if (this.options.disableIfEmpty && $('option', this.$select).length <= 0) {
                 this.disable();
             }
             else {
                 this.enable();
             }
-
+            
             if (this.options.dropRight) {
                 this.$ul.addClass('pull-right');
             }
@@ -1424,23 +1424,23 @@
         /**
          * The provided data will be used to build the dropdown.
          */
-        dataprovider: function (dataprovider) {
-
+        dataprovider: function(dataprovider) {
+            
             var groupCounter = 0;
             var $select = this.$select.empty();
-
+            
             $.each(dataprovider, function (index, option) {
                 var $tag;
-
+                
                 if ($.isArray(option.children)) { // create optiongroup tag
                     groupCounter++;
-
+                    
                     $tag = $('<optgroup/>').attr({
                         label: option.label || 'Group ' + groupCounter,
                         disabled: !!option.disabled
                     });
-
-                    forEach(option.children, function (subOption) { // add children option tags
+                    
+                    forEach(option.children, function(subOption) { // add children option tags
                         $tag.append($('<option/>').attr({
                             value: subOption.value,
                             label: subOption.label || subOption.value,
@@ -1461,17 +1461,17 @@
                     });
                     $tag.text(option.label || option.value);
                 }
-
+                
                 $select.append($tag);
             });
-
+            
             this.rebuild();
         },
 
         /**
          * Enable the multiselect.
          */
-        enable: function () {
+        enable: function() {
             this.$select.prop('disabled', false);
             this.$button.prop('disabled', false)
                 .removeClass('disabled');
@@ -1480,7 +1480,7 @@
         /**
          * Disable the multiselect.
          */
-        disable: function () {
+        disable: function() {
             this.$select.prop('disabled', true);
             this.$button.prop('disabled', true)
                 .addClass('disabled');
@@ -1491,7 +1491,7 @@
          *
          * @param {Array} options
          */
-        setOptions: function (options) {
+        setOptions: function(options) {
             this.options = this.mergeOptions(options);
         },
 
@@ -1501,7 +1501,7 @@
          * @param {Array} options
          * @returns {Array}
          */
-        mergeOptions: function (options) {
+        mergeOptions: function(options) {
             return $.extend(true, {}, this.defaults, this.options, options);
         },
 
@@ -1510,21 +1510,21 @@
          *
          * @returns {Boolean}
          */
-        hasSelectAll: function () {
+        hasSelectAll: function() {
             return $('li.multiselect-all', this.$ul).length > 0;
         },
 
         /**
          * Updates the select all checkbox based on the currently displayed and selected checkboxes.
          */
-        updateSelectAll: function (notTriggerOnSelectAll) {
+        updateSelectAll: function(notTriggerOnSelectAll) {
             if (this.hasSelectAll()) {
                 var allBoxes = $("li:not(.multiselect-item):not(.filter-hidden) input:enabled", this.$ul);
                 var allBoxesLength = allBoxes.length;
                 var checkedBoxesLength = allBoxes.filter(":checked").length;
-                var selectAllLi = $("li.multiselect-all", this.$ul);
+                var selectAllLi  = $("li.multiselect-all", this.$ul);
                 var selectAllInput = selectAllLi.find("input");
-
+                
                 if (checkedBoxesLength > 0 && checkedBoxesLength === allBoxesLength) {
                     selectAllInput.prop("checked", true);
                     selectAllLi.addClass(this.options.selectedClass);
@@ -1545,9 +1545,9 @@
         /**
          * Update the button text and its title based on the currently selected options.
          */
-        updateButtonText: function () {
+        updateButtonText: function() {
             var options = this.getSelected();
-
+            
             // First update the displayed button text.
             if (this.options.enableHTML) {
                 $('.multiselect .multiselect-selected-text', this.$container).html(this.options.buttonText(options, this.$select));
@@ -1555,7 +1555,7 @@
             else {
                 $('.multiselect .multiselect-selected-text', this.$container).text(this.options.buttonText(options, this.$select));
             }
-
+            
             // Now update the title attribute of the button.
             $('.multiselect', this.$container).attr('title', this.options.buttonTitle(options, this.$select));
         },
@@ -1565,7 +1565,7 @@
          *
          * @returns {jQUery}
          */
-        getSelected: function () {
+        getSelected: function() {
             return $('option', this.$select).filter(":selected");
         },
 
@@ -1610,25 +1610,25 @@
         /**
          * Used for knockout integration.
          */
-        updateOriginalOptions: function () {
+        updateOriginalOptions: function() {
             this.originalOptions = this.$select.clone()[0].options;
         },
 
-        asyncFunction: function (callback, timeout, self) {
+        asyncFunction: function(callback, timeout, self) {
             var args = Array.prototype.slice.call(arguments, 3);
-            return setTimeout(function () {
+            return setTimeout(function() {
                 callback.apply(self || window, args);
             }, timeout);
         },
 
-        setAllSelectedText: function (allSelectedText) {
+        setAllSelectedText: function(allSelectedText) {
             this.options.allSelectedText = allSelectedText;
             this.updateButtonText();
         }
     };
 
-    $.fn.multiselect = function (option, parameter, extraOptions) {
-        return this.each(function () {
+    $.fn.multiselect = function(option, parameter, extraOptions) {
+        return this.each(function() {
             var data = $(this).data('multiselect');
             var options = typeof option === 'object' && option;
 
@@ -1641,7 +1641,7 @@
             // Call multiselect method.
             if (typeof option === 'string') {
                 data[option](parameter, extraOptions);
-
+                
                 if (option === 'destroy') {
                     $(this).data('multiselect', false);
                 }
@@ -1651,7 +1651,7 @@
 
     $.fn.multiselect.Constructor = Multiselect;
 
-    $(function () {
+    $(function() {
         $("select[data-role=multiselect]").multiselect();
     });
 

--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1133,19 +1133,19 @@
          * @returns string
          */
         replaceDiacritics: function (s) {
-            var in_chrs = '¹²³áàâãäåaaaÀÁÂÃÄÅAAAÆccç©CCÇÐÐèéê?əëeeeeeÈÊË?EEEEE€gGiìíîïìiiiÌÍÎÏ?ÌIIIlLnnñNNÑòóôõöoooøÒÓÔÕÖOOOØŒr®Ršs?ßŠS?ùúûüuuuuÙÚÛÜUUUUýÿÝŸžzzŽZZ',
-                out_chrs = '123aaaaaaaaaaaaaaaaaaacccccccddeeeeeeeeeeeeeeeeeeeeeggiiiiiiiiiiiiiiiiiillnnnnnnoooooooooooooooorrrsssssssuuuuuuuuuuuuuuuuyyyyzzzzzz',
-                chars_rgx = new RegExp('[' + in_chrs + ']', 'g'),
+            var _in  = '¹²³áàâãäåaaaÀÁÂÃÄÅAAAÆccç©CCÇÐÐèéêəëeeeeeÈÊËEEEEE€gGiìíîïìiiiÌÍÎÏÌIIIlLnnñNNÑòóôõöoooøÒÓÔÕÖOOOØŒ®ЯšsßŠSùúûüuuuuÙÚÛÜUUUUýÿÝŸžzzŽZZ',
+                _out = '123aaaaaaaaaAAAAAAAAAaccccCCCDDeeeeeeeeeeEEEEEEEEEgGiiiiiiiiiIIIIIIIIILnnnNNNoooooooooOOOOOOOOOOcRssbSSuuuuuuuuUUUUUUUUyyYYzzzZZZ',
+                _rgx = new RegExp('[' + _in + ']', 'g'),
                 transl = {}, i,
                 lookup = function (m) {
                     return transl[m] || m;
                 };
 
-            for (i = 0; i < in_chrs.length; i++) {
-                transl[in_chrs[i]] = out_chrs[i];
+            for (i = 0; i < _in.length; i++) {
+                transl[_in[i]] = _out[i];
             }
 
-            return s.replace(chars_rgx, lookup);
+            return s.replace(_rgx, lookup);
         },
 
         /**

--- a/index.html
+++ b/index.html
@@ -1,75 +1,82 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <title>Bootstrap Multiselect</title>
-        <meta name="robots" content="noindex, nofollow" />
-        <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<head>
+    <title>Bootstrap Multiselect</title>
+    <meta name="robots" content="noindex, nofollow"/>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
 
-        <link rel="stylesheet" href="docs/css/bootstrap-3.3.2.min.css" type="text/css">
-        <link rel="stylesheet" href="docs/css/bootstrap-example.css" type="text/css">
-        <link rel="stylesheet" href="docs/css/prettify.css" type="text/css">
+    <link rel="stylesheet" href="docs/css/bootstrap-3.3.2.min.css" type="text/css">
+    <link rel="stylesheet" href="docs/css/bootstrap-example.css" type="text/css">
+    <link rel="stylesheet" href="docs/css/prettify.css" type="text/css">
 
-        <script type="text/javascript" src="docs/js/jquery-2.1.3.min.js"></script>
-        <script type="text/javascript" src="docs/js/bootstrap-3.3.2.min.js"></script>
-        <script type="text/javascript" src="docs/js/prettify.js"></script>
+    <script type="text/javascript" src="docs/js/jquery-2.1.3.min.js"></script>
+    <script type="text/javascript" src="docs/js/bootstrap-3.3.2.min.js"></script>
+    <script type="text/javascript" src="docs/js/prettify.js"></script>
 
-        <link rel="stylesheet" href="dist/css/bootstrap-multiselect.css" type="text/css">
-        <script type="text/javascript" src="dist/js/bootstrap-multiselect.js"></script>
+    <link rel="stylesheet" href="dist/css/bootstrap-multiselect.css" type="text/css">
+    <script type="text/javascript" src="dist/js/bootstrap-multiselect.js"></script>
 
-        <script type="text/javascript">
-            $(document).ready(function() {
-                window.prettyPrint() && prettyPrint();
-            });
-        </script>
-    </head>
-    <body data-spy="scroll" data-target="#affix">
-	<a href="https://github.com/davidstutz/bootstrap-multiselect"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub"></a>
+    <script type="text/javascript">
+        $(document).ready(function () {
+            window.prettyPrint() && prettyPrint();
+        });
+    </script>
+</head>
+<body data-spy="scroll" data-target="#affix">
+<a href="https://github.com/davidstutz/bootstrap-multiselect"><img
+        style="position: absolute; top: 0; right: 0; border: 0;"
+        src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub"></a>
 
-        <div class="container">
-            <div class="row">
-                <div class="col-md-3" id="affix">
-                    <ul class="nav nav-pills nav-stacked sidebar" data-spy="affix" style="margin-top: 40px;">
-                        <li class="active"><a href="#getting-started">Getting Started</a></li>
-                        <li><a href="#configuration-options">Configuration Options</a></li>
-                        <li><a href="#templates">Templates</a></li>
-                        <li><a href="#methods">Methods</a></li>
-                        <li><a href="#further-examples">Further Examples</a></li>
-                        <li><a href="#post">Server-Side Processing</a></li>
-                        <li><a href="#keyboard-support">Keyboard Support</a>
-                        <li><a href="#faq">Frequently Asked Questions</a></li>
-                        <li><a href="#known-issues">Known Issues</a></li>
-                        <li><a href="tests/SpecRunner.html">Tests</a></li>
-                        <li><a href="#license">License</a></li>
-                    </ul>
-                </div>
-                <div class="col-md-9">
-                    <div class="page-header">
-                        <h1>Bootstrap Multiselect</h1>
-                    </div>
-                    
-                    <p class="alert alert-warning">
-                        <b>Some option names may have changed during the last few commits!</b>
+<div class="container">
+    <div class="row">
+        <div class="col-md-3" id="affix">
+            <ul class="nav nav-pills nav-stacked sidebar" data-spy="affix" style="margin-top: 40px;">
+                <li class="active"><a href="#getting-started">Getting Started</a></li>
+                <li><a href="#configuration-options">Configuration Options</a></li>
+                <li><a href="#templates">Templates</a></li>
+                <li><a href="#methods">Methods</a></li>
+                <li><a href="#further-examples">Further Examples</a></li>
+                <li><a href="#post">Server-Side Processing</a></li>
+                <li><a href="#keyboard-support">Keyboard Support</a>
+                <li><a href="#faq">Frequently Asked Questions</a></li>
+                <li><a href="#known-issues">Known Issues</a></li>
+                <li><a href="tests/SpecRunner.html">Tests</a></li>
+                <li><a href="#license">License</a></li>
+            </ul>
+        </div>
+        <div class="col-md-9">
+            <div class="page-header">
+                <h1>Bootstrap Multiselect</h1>
+            </div>
+
+            <p class="alert alert-warning">
+                <b>Some option names may have changed during the last few commits!</b>
+            </p>
+
+            <p class="alert alert-info">
+                <b>Please consult the <a href="#faq">FAQ</a> and the <a
+                        href="https://github.com/davidstutz/bootstrap-multiselect/issues">Issue Tracker</a> before
+                    creating a new issue.</b>
+            </p>
+
+            <p class="alert alert-info">
+                <b>Please have a look at <a href="#how-to-contribute">How to contribute?</a> and the <a
+                        href="https://github.com/davidstutz/bootstrap-multiselect/issues">Issue Tracker</a>.</b>
+            </p>
+
+            <div class="page-header">
+                <h2 id="getting-started">Getting Started</h2>
+            </div>
+
+            <ol>
+                <li>
+                    <h3>Link the Required Files</h3>
+
+                    <p>
+                        First, the <a href="http://jquery.com/" target="_blank">jQuery</a> library needs to be included.
+                        Then <a href="http://getbootstrap.com" target="_blank">Twitter Bootstrap</a> - both the
+                        Javascript library and the CSS stylesheet - needs to be included.
                     </p>
-                    
-                    <p class="alert alert-info">
-                        <b>Please consult the <a href="#faq">FAQ</a> and the <a href="https://github.com/davidstutz/bootstrap-multiselect/issues">Issue Tracker</a> before creating a new issue.</b>
-                    </p>
-                    
-                    <p class="alert alert-info">
-                        <b>Please have a look at <a href="#how-to-contribute">How to contribute?</a> and the <a href="https://github.com/davidstutz/bootstrap-multiselect/issues">Issue Tracker</a>.</b>
-                    </p>
-                    
-                    <div class="page-header">
-                        <h2 id="getting-started">Getting Started</h2>
-                    </div>
-
-                    <ol>
-                        <li>
-                            <h3>Link the Required Files</h3>
-
-                            <p>
-                                First, the <a href="http://jquery.com/" target="_blank">jQuery</a> library needs to be included. Then <a href="http://getbootstrap.com" target="_blank">Twitter Bootstrap</a> - both the Javascript library and the CSS stylesheet - needs to be included.
-                            </p>
 
 <pre class="prettyprint linenums">
 &lt;!-- Include Twitter Bootstrap and jQuery: --&gt;
@@ -82,24 +89,31 @@
 &lt;link rel=&quot;stylesheet&quot; href=&quot;css/bootstrap-multiselect.css&quot; type=&quot;text/css&quot;/&gt;
 </pre>
 
-                            <p>
-                                The jQuery library can also be included using a CDN, for example the <a href="https://developers.google.com/speed/libraries/devguide?hl=de&csw=1#jquery">Google CDN</a>:
-                            </p>
+                    <p>
+                        The jQuery library can also be included using a CDN, for example the <a
+                            href="https://developers.google.com/speed/libraries/devguide?hl=de&csw=1#jquery">Google
+                        CDN</a>:
+                    </p>
 
 <pre class="prettyprint linenums">
 &lt;script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"&gt;&lt;/script&gt;
 </pre>
 
-                            <p class="alert alert-info">
-                                Note that the plugin will work both with version 2.x of the jQuery library as well as with version 1.10.x of the jQuery library. So for using the Google CDN you may have to adjust the version.
-                            </p>
-                        </li>
-                        <li>
-                            <h3>Create a Select</h3>
+                    <p class="alert alert-info">
+                        Note that the plugin will work both with version 2.x of the jQuery library as well as with
+                        version 1.10.x of the jQuery library. So for using the Google CDN you may have to adjust the
+                        version.
+                    </p>
+                </li>
+                <li>
+                    <h3>Create a Select</h3>
 
-                            <p>
-                                Now simply use HTML to create your <code>select</code> input which you want to turn into a multiselect. Remember to set the <code>multiple</code> attribute as to get a real multiselect - but do not worry, the plugin can also be used as usual select without the <code>multiple</code> attribute being present.
-                            </p>
+                    <p>
+                        Now simply use HTML to create your <code>select</code> input which you want to turn into a
+                        multiselect. Remember to set the <code>multiple</code> attribute as to get a real multiselect -
+                        but do not worry, the plugin can also be used as usual select without the <code>multiple</code>
+                        attribute being present.
+                    </p>
 
 <pre class="prettyprint linenums">
 &lt;!-- Build your select: --&gt;
@@ -112,30 +126,31 @@
     &lt;option value=&quot;onions&quot;&gt;Onions&lt;/option&gt;
 &lt;/select&gt;
 </pre>
-                        </li>
-                        <li>
-                            <h3>Call the Plugin</h3>
+                </li>
+                <li>
+                    <h3>Call the Plugin</h3>
 
-                            <p>
-                                In the end, simply call the plugin on your <code>select</code>. You may also specify further options, see the Options tab for further information.
-                            </p>
+                    <p>
+                        In the end, simply call the plugin on your <code>select</code>. You may also specify further
+                        options, see the Options tab for further information.
+                    </p>
 
-                            <div class="example">
-                                <script type="text/javascript">
-                                    $(document).ready(function() {
-                                        $('#example-getting-started').multiselect();
-                                    });
-                                </script>
-                                <select id="example-getting-started" multiple="multiple">
-                                    <option value="cheese">Cheese</option>
-                                    <option value="tomatoes">Tomatoes</option>
-                                    <option value="Mozzarella">Mozzarella</option>
-                                    <option value="Mushrooms">Mushrooms</option>
-                                    <option value="Pepperoni">Pepperoni</option>
-                                    <option value="Onions">Onions</option>
-                                </select>
-                            </div>
-                            <div class="highlight">
+                    <div class="example">
+                        <script type="text/javascript">
+                            $(document).ready(function () {
+                                $('#example-getting-started').multiselect();
+                            });
+                        </script>
+                        <select id="example-getting-started" multiple="multiple">
+                            <option value="cheese">Cheese</option>
+                            <option value="tomatoes">Tomatoes</option>
+                            <option value="Mozzarella">Mozzarella</option>
+                            <option value="Mushrooms">Mushrooms</option>
+                            <option value="Pepperoni">Pepperoni</option>
+                            <option value="Onions">Onions</option>
+                        </select>
+                    </div>
+                    <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;!-- Initialize the plugin: --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
@@ -144,129 +159,151 @@
     });
 &lt;/script&gt;
 </pre>
-                            </div>
-                        </li>
-                    </ol>
-                    
-                    <div class="page-header">
-                        <h2 id="configuration-options">Configuration Options</h2>
                     </div>
-                    
-                    <table class="table table-condensed">
-                        <thead>
-                            <tr>
-                                <th colspan="3">
-                                    Overview
-                                </th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td><a href="#configuration-options-multiple"><code>multiple</code></a></td>
-                                <td><a href="#configuration-options-enableHTML"><code>enableHTML</code></a></td>
-                                <td><a href="#configuration-options-enableClickableOptGroups"><code>enableClickableOptGroups</code></a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="#configuration-options-enableCollapsibleOptGroups"><code>enableCollapsibleOptGroups</code></a></td>
-                                <td><a href="#configuration-options-disableIfEmpty"><code>disableIfEmpty</code></a></td>
-                                <td><a href="#configuration-options-dropRight"><code>dropRight</code></a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="#configuration-options-dropUp"><code>dropUp</code></a></td>
-                                <td><a href="#configuration-options-maxHeight"><code>maxHeight</code></a></td>
-                                <td><a href="#configuration-options-disableIfEmpty"><code>disableIfEmpty</code></a></td>
-                            <tr>
-                            <tr>
-                                <td><a href="#configuration-options-disabledText"><code>disabledText</code></a>
-                                <td><a href="#configuration-options-onChange"><code>onChange</code></a></td>
-                                <td><a href="#configuration-options-onInitialized"><code>onInitialized</code></a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="#configuration-options-onDropdownShow"><code>onDropdownShow</code></a></td>
-                                <td><a href="#configuration-options-onDropdownHide"><code>onDropdownHide</code></a></td>
-                                <td><a href="#configuration-options-onDropdownShown"><code>onDropdownShown</code></a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="#configuration-options-onDropdownHidden"><code>onDropdownHidden</code></a></td>
-                                <td><a href="#configuration-options-buttonClass"><code>buttonClass</code></a></td>
-                                <td><a href="#configuration-options-inheritClass"><code>inheritClass</code></a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="#configuration-options-buttonContainer"><code>buttonContainer</code></a></td>
-                                <td><a href="#configuration-options-buttonWidth"><code>buttonWidth</code></a></td>
-                                <td><a href="#configuration-options-buttonText"><code>buttonText</code></a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="#configuration-options-buttonTitle"><code>buttonTitle</code></a></td>
-                                <td><a href="#configuration-options-nonSelectedText"><code>nonSelectedText</code></a></td>
-                                <td><a href="#configuration-options-nSelectedText"><code>nSelectedText</code></a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="#configuration-options-allSelectedText"><code>allSelectedText</code></a></td>
-                                <td><a href="#configuration-options-numberDisplayed"><code>numberDisplayed</code></a></td>
-                                <td><a href="#configuration-options-delimiterText"><code>delimiterText</code></a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="#configuration-options-optionLabel"><code>optionLabel</code></a></td>
-                                <td><a href="#configuration-options-optionClass"><code>optionClass</code></a></td>
-                                <td><a href="#configuration-options-selectedClass"><code>selectedClass</code></a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="#configuration-options-includeSelectAllOption"><code>includeSelectAllOption</code></a></td>
-                                <td><a href="#configuration-options-selectAllJustVisible"><code>selectAllJustVisible</code></a></td>
-                                <td><a href="#configuration-options-selectAllText"><code>selectAllText</code></a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="#configuration-options-selectAllValue"><code>selectAllValue</code></a></td>
-                                <td><a href="#configuration-options-selectAllName"><code>selectAllName</code></a></td>
-                                <td><a href="#configuration-options-selectAllNumber"><code>selectAllNumber</code></a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="#configuration-options-onSelectAll"><code>onSelectAll</code></a></td>
-                                <td><a href="#configuration-options-enableFiltering"><code>enableFiltering</code></a></td>
-                                <td><a href="#configuration-options-enableCaseInsensitiveFiltering"><code>enableCaseInsensitiveFiltering</code></a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="#configuration-options-enableFullValueFiltering"><code>enableFullValueFiltering</code></a></td>
-                                <td><a href="#configuration-options-filterBehavior"><code>filterBehavior</code></a></td>
-                                <td><a href="#configuration-options-filterPlaceholder"><code>filterPlaceholder</code></a></td>
-                            </tr>
-                        </tbody>
-                    </table>
-                    
-                    <p class="alert alert-info">
-                        Use Firebug, Chrome Developer Tools to get the best out of the below examples.
-                    </p>
-                    
-                    <table class="table">
-                        <tbody>
-                            <tr>
-                                <td><code id="configuration-options-multiple">multiple</code></td>
-                                <td>
-                                    <p>
-                                        <code>multiple</code> is not a real configuration option. It refers to the <code>multiple</code> attribute of the <code>select</code> the plugin is applied on. When the <code>multiple</code> attribute of the <code>select</code> is present, the plugin uses checkboxes to allow multiple selections. If it is not present, the plugin uses radio buttons to allow single selections. When using the plugin for single selections (without the <code>multiple</code> attribute present), the first option will automatically be selected if no other option is selected in advance. See <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/129">#129</a> for how to avoid this behavior.
-                                    </p>
-                                    
-                                    <p>
-                                        The following example shows the default behavior when the <code>multiple</code> attribute is omitted:
-                                    </p>
+                </li>
+            </ol>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-single').multiselect();
-                                            });
-                                        </script>
-                                        <select id="example-single">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+            <div class="page-header">
+                <h2 id="configuration-options">Configuration Options</h2>
+            </div>
+
+            <table class="table table-condensed">
+                <thead>
+                <tr>
+                    <th colspan="3">
+                        Overview
+                    </th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td><a href="#configuration-options-multiple"><code>multiple</code></a></td>
+                    <td><a href="#configuration-options-enableHTML"><code>enableHTML</code></a></td>
+                    <td><a href="#configuration-options-enableClickableOptGroups"><code>enableClickableOptGroups</code></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <a href="#configuration-options-enableCollapsibleOptGroups"><code>enableCollapsibleOptGroups</code></a>
+                    </td>
+                    <td><a href="#configuration-options-disableIfEmpty"><code>disableIfEmpty</code></a></td>
+                    <td><a href="#configuration-options-dropRight"><code>dropRight</code></a></td>
+                </tr>
+                <tr>
+                    <td><a href="#configuration-options-dropUp"><code>dropUp</code></a></td>
+                    <td><a href="#configuration-options-maxHeight"><code>maxHeight</code></a></td>
+                    <td><a href="#configuration-options-disableIfEmpty"><code>disableIfEmpty</code></a></td>
+                <tr>
+                <tr>
+                    <td><a href="#configuration-options-disabledText"><code>disabledText</code></a>
+                    <td><a href="#configuration-options-onChange"><code>onChange</code></a></td>
+                    <td><a href="#configuration-options-onInitialized"><code>onInitialized</code></a></td>
+                </tr>
+                <tr>
+                    <td><a href="#configuration-options-onDropdownShow"><code>onDropdownShow</code></a></td>
+                    <td><a href="#configuration-options-onDropdownHide"><code>onDropdownHide</code></a></td>
+                    <td><a href="#configuration-options-onDropdownShown"><code>onDropdownShown</code></a></td>
+                </tr>
+                <tr>
+                    <td><a href="#configuration-options-onDropdownHidden"><code>onDropdownHidden</code></a></td>
+                    <td><a href="#configuration-options-buttonClass"><code>buttonClass</code></a></td>
+                    <td><a href="#configuration-options-inheritClass"><code>inheritClass</code></a></td>
+                </tr>
+                <tr>
+                    <td><a href="#configuration-options-buttonContainer"><code>buttonContainer</code></a></td>
+                    <td><a href="#configuration-options-buttonWidth"><code>buttonWidth</code></a></td>
+                    <td><a href="#configuration-options-buttonText"><code>buttonText</code></a></td>
+                </tr>
+                <tr>
+                    <td><a href="#configuration-options-buttonTitle"><code>buttonTitle</code></a></td>
+                    <td><a href="#configuration-options-nonSelectedText"><code>nonSelectedText</code></a></td>
+                    <td><a href="#configuration-options-nSelectedText"><code>nSelectedText</code></a></td>
+                </tr>
+                <tr>
+                    <td><a href="#configuration-options-allSelectedText"><code>allSelectedText</code></a></td>
+                    <td><a href="#configuration-options-numberDisplayed"><code>numberDisplayed</code></a></td>
+                    <td><a href="#configuration-options-delimiterText"><code>delimiterText</code></a></td>
+                </tr>
+                <tr>
+                    <td><a href="#configuration-options-optionLabel"><code>optionLabel</code></a></td>
+                    <td><a href="#configuration-options-optionClass"><code>optionClass</code></a></td>
+                    <td><a href="#configuration-options-selectedClass"><code>selectedClass</code></a></td>
+                </tr>
+                <tr>
+                    <td><a href="#configuration-options-includeSelectAllOption"><code>includeSelectAllOption</code></a>
+                    </td>
+                    <td><a href="#configuration-options-selectAllJustVisible"><code>selectAllJustVisible</code></a></td>
+                    <td><a href="#configuration-options-selectAllText"><code>selectAllText</code></a></td>
+                </tr>
+                <tr>
+                    <td><a href="#configuration-options-selectAllValue"><code>selectAllValue</code></a></td>
+                    <td><a href="#configuration-options-selectAllName"><code>selectAllName</code></a></td>
+                    <td><a href="#configuration-options-selectAllNumber"><code>selectAllNumber</code></a></td>
+                </tr>
+                <tr>
+                    <td><a href="#configuration-options-onSelectAll"><code>onSelectAll</code></a></td>
+                    <td><a href="#configuration-options-enableFiltering"><code>enableFiltering</code></a></td>
+                    <td><a href="#configuration-options-enableCaseInsensitiveFiltering"><code>enableCaseInsensitiveFiltering</code></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a href="#configuration-options-enableFullValueFiltering"><code>enableFullValueFiltering</code></a>
+                    </td>
+                    <td><a href="#configuration-options-filterBehavior"><code>filterBehavior</code></a></td>
+                    <td><a href="#configuration-options-filterPlaceholder"><code>filterPlaceholder</code></a></td>
+                </tr>
+                <tr>
+                    <td>
+                        <a href="#configuration-options-enableReplaceDiacritics"><code>enableReplaceDiacritics</code></a>
+                    </td>
+                    <td></td>
+                    <td></td>
+                </tr>
+                </tbody>
+            </table>
+
+            <p class="alert alert-info">
+                Use Firebug, Chrome Developer Tools to get the best out of the below examples.
+            </p>
+
+            <table class="table">
+                <tbody>
+                <tr>
+                    <td><code id="configuration-options-multiple">multiple</code></td>
+                    <td>
+                        <p>
+                            <code>multiple</code> is not a real configuration option. It refers to the
+                            <code>multiple</code> attribute of the <code>select</code> the plugin is applied on. When
+                            the <code>multiple</code> attribute of the <code>select</code> is present, the plugin uses
+                            checkboxes to allow multiple selections. If it is not present, the plugin uses radio buttons
+                            to allow single selections. When using the plugin for single selections (without the <code>multiple</code>
+                            attribute present), the first option will automatically be selected if no other option is
+                            selected in advance. See <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/129">#129</a> for how
+                            to avoid this behavior.
+                        </p>
+
+                        <p>
+                            The following example shows the default behavior when the <code>multiple</code> attribute is
+                            omitted:
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-single').multiselect();
+                                });
+                            </script>
+                            <select id="example-single">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $('#example-single').multiselect();
@@ -281,28 +318,30 @@
     &lt;option value="6"&gt;Option 6&lt;/option&gt;
 &lt;/select&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        If multiple options are selected in advance and the <code>select</code> lacks the <code>multiple</code> attribute, the last option marked as <code>selected</code> will initially be selected by the plugin.
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-single-selected').multiselect();
-                                            });
-                                        </script>
-                                        <select id="example-single-selected">
-                                            <option value="1">Option 1</option>
-                                            <option value="2" selected="selected">Option 2</option>
-                                            <option value="3" selected="selected">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+
+                        <p>
+                            If multiple options are selected in advance and the <code>select</code> lacks the <code>multiple</code>
+                            attribute, the last option marked as <code>selected</code> will initially be selected by the
+                            plugin.
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-single-selected').multiselect();
+                                });
+                            </script>
+                            <select id="example-single-selected">
+                                <option value="1">Option 1</option>
+                                <option value="2" selected="selected">Option 2</option>
+                                <option value="3" selected="selected">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $('#example-single-selected').multiselect();
@@ -318,28 +357,29 @@
     &lt;option value="6"&gt;Option 6&lt;/option&gt;
 &lt;/select&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        The following example shows the default behavior when the <code>multiple</code> attribute is present. Initially selected options will be adopted automatically:
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-multiple-selected').multiselect();
-                                            });
-                                        </script>
-                                        <select id="example-multiple-selected" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2" selected="selected">Option 2</option>
-                                            <option value="3" selected="selected">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+
+                        <p>
+                            The following example shows the default behavior when the <code>multiple</code> attribute is
+                            present. Initially selected options will be adopted automatically:
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-multiple-selected').multiselect();
+                                });
+                            </script>
+                            <select id="example-multiple-selected" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2" selected="selected">Option 2</option>
+                                <option value="3" selected="selected">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $('#example-multiple-selected').multiselect();
@@ -355,30 +395,32 @@
     &lt;option value="6"&gt;Option 6&lt;/option&gt;
 &lt;/select&gt;
 </pre>
-                                    
-                                    <p>
-                                        The plugin naturally supports <code>optgroup</code>'s, however the group headers are not clickable by default. See the <code>enableClickableOptGroups</code> option for details.
-                                    </p>
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-multiple-optgroups').multiselect();
-                                            });
-                                        </script>
-                                        <select id="example-multiple-optgroups" multiple="multiple">
-                                            <optgroup label="Group 1">
-                                                <option value="1-1">Option 1.1</option>
-                                                <option value="1-2" selected="selected">Option 1.2</option>
-                                                <option value="1-3" selected="selected">Option 1.3</option>
-                                            </optgroup>
-                                            <optgroup label="Group 2">
-                                                <option value="2-1">Option 2.1</option>
-                                                <option value="2-2">Option 2.2</option>
-                                                <option value="2-3">Option 2.3</option>
-                                            </optgroup>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+
+                            <p>
+                                The plugin naturally supports <code>optgroup</code>'s, however the group headers are not
+                                clickable by default. See the <code>enableClickableOptGroups</code> option for details.
+                            </p>
+
+                            <div class="example">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-multiple-optgroups').multiselect();
+                                    });
+                                </script>
+                                <select id="example-multiple-optgroups" multiple="multiple">
+                                    <optgroup label="Group 1">
+                                        <option value="1-1">Option 1.1</option>
+                                        <option value="1-2" selected="selected">Option 1.2</option>
+                                        <option value="1-3" selected="selected">Option 1.3</option>
+                                    </optgroup>
+                                    <optgroup label="Group 2">
+                                        <option value="2-1">Option 2.1</option>
+                                        <option value="2-2">Option 2.2</option>
+                                        <option value="2-3">Option 2.3</option>
+                                    </optgroup>
+                                </select>
+                            </div>
+                            <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $('#example-multiple-optgroups').multiselect();
@@ -396,27 +438,29 @@
     &lt;/optgroup&gt;
 &lt;/select&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-enableHTML">enableHTML</code></td>
-                                <td>
-                                    <p>
-                                        XSS injection is a serious thread for all modern web applications. Setting <code>enableHTML</code> to <code>false</code> (default setting) will create a XSS save multiselect.
-                                    </p>
+                            </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-enableHTML">enableHTML</code></td>
+                    <td>
+                        <p>
+                            XSS injection is a serious thread for all modern web applications. Setting
+                            <code>enableHTML</code> to <code>false</code> (default setting) will create a XSS save
+                            multiselect.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-xss').multiselect();
-                                            });
-                                        </script>
-                                        <select id="example-xss" multiple="multiple">
-                                            <option value="1">&lt;script&gt;alert(1);&lt;/script&gt;</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-xss').multiselect();
+                                });
+                            </script>
+                            <select id="example-xss" multiple="multiple">
+                                <option value="1">&lt;script&gt;alert(1);&lt;/script&gt;</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type="text/javascript"&gt;
     $(document).ready(function() {
@@ -428,64 +472,68 @@
 &lt;/select&gt;
 </pre>
 
-                                    <p>On the other hand, when setting <code>enableHTML</code> to <code>true</code>, the plugin will support HTML within <code>option</code>s:</p>
+                            <p>On the other hand, when setting <code>enableHTML</code> to <code>true</code>, the plugin
+                                will support HTML within <code>option</code>s:</p>
 
-                                    <div class="example">
-                                    <script type="text/javascript">
-                                        $(document).ready(function() {
-                                            $('#example-xss-html').multiselect({
-                                                nonSelectedText: '<span style="color:red;">Non selected ...</span>',
-                                                enableHTML: true
-                                            });
+                            <div class="example">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-xss-html').multiselect({
+                                            nonSelectedText: '<span style="color:red;">Non selected ...</span>',
+                                            enableHTML: true
                                         });
-                                    </script>
-                                    <select id="example-xss-html" multiple="multiple">
-                                        <option value="1">&lt;span style=&quot;color:red&quot;&gt;Option 1&lt;/span&gt;</option>
-                                    </select>
-                                </div>
-                                <div class="highlight">
+                                    });
+                                </script>
+                                <select id="example-xss-html" multiple="multiple">
+                                    <option value="1">&lt;span style=&quot;color:red&quot;&gt;Option
+                                        1&lt;/span&gt;</option>
+                                </select>
+                            </div>
+                            <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type="text/javascript"&gt;
     $(doclect&gt;
-</pre>ument).ready(function() {
-        $('#example-xss-html').multiselect();
-    });
-&lt;/script&gt;
-&lt;select id="example-xss-html" multiple="multiple"&gt;
-    &lt;option value="1"&gt;&amp;gt;span style="color:red"&amp;lt;Option 1&amp;gt;/span&amp;gt;&lt;/option&gt;
-&lt;/select&gt;
 </pre>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-enableClickableOptGroups">enableClickableOptGroups</code></td>
-                                <td>
-                                    <p>
-                                        If set to <code>true</code>, <code>optgroup</code>'s will be clickable, allowing to easily select multiple options belonging to the same group.
-                                    </p>
+                                ument).ready(function() {
+                                $('#example-xss-html').multiselect();
+                                });
+                                &lt;/script&gt;
+                                &lt;select id="example-xss-html" multiple="multiple"&gt;
+                                &lt;option value="1"&gt;&amp;gt;span style="color:red"&amp;lt;Option 1&amp;gt;/span&amp;gt;&lt;/option&gt;
+                                &lt;/select&gt;
+                                </pre>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-enableClickableOptGroups">enableClickableOptGroups</code></td>
+                    <td>
+                        <p>
+                            If set to <code>true</code>, <code>optgroup</code>'s will be clickable, allowing to easily
+                            select multiple options belonging to the same group.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-enableClickableOptGroups').multiselect({
-                                                    enableClickableOptGroups: true
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-enableClickableOptGroups" multiple="multiple">
-                                            <optgroup label="Group 1">
-                                                <option value="1-1">Option 1.1</option>
-                                                <option value="1-2" selected="selected">Option 1.2</option>
-                                                <option value="1-3" selected="selected">Option 1.3</option>
-                                            </optgroup>
-                                            <optgroup label="Group 2">
-                                                <option value="2-1">Option 2.1</option>
-                                                <option value="2-2">Option 2.2</option>
-                                                <option value="2-3">Option 2.3</option>
-                                            </optgroup>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-enableClickableOptGroups').multiselect({
+                                        enableClickableOptGroups: true
+                                    });
+                                });
+                            </script>
+                            <select id="example-enableClickableOptGroups" multiple="multiple">
+                                <optgroup label="Group 1">
+                                    <option value="1-1">Option 1.1</option>
+                                    <option value="1-2" selected="selected">Option 1.2</option>
+                                    <option value="1-3" selected="selected">Option 1.3</option>
+                                </optgroup>
+                                <optgroup label="Group 2">
+                                    <option value="2-1">Option 2.1</option>
+                                    <option value="2-2">Option 2.2</option>
+                                    <option value="2-3">Option 2.3</option>
+                                </optgroup>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -495,35 +543,35 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        Note that this option does also work with disabled options:
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-enableClickableOptGroups-disabled').multiselect({
-                                                    enableClickableOptGroups: true,
-                                                    includeSelectAllOption: true
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-enableClickableOptGroups-disabled" multiple="multiple">
-                                            <optgroup label="Group 1">
-                                                <option value="1-1" disabled>Option 1.1</option>
-                                                <option value="1-2" selected="selected">Option 1.2</option>
-                                                <option value="1-3" selected="selected">Option 1.3</option>
-                                            </optgroup>
-                                            <optgroup label="Group 2">
-                                                <option value="2-1" disabled>Option 2.1</option>
-                                                <option value="2-2">Option 2.2</option>
-                                                <option value="2-3">Option 2.3</option>
-                                            </optgroup>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+
+                        <p>
+                            Note that this option does also work with disabled options:
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-enableClickableOptGroups-disabled').multiselect({
+                                        enableClickableOptGroups: true,
+                                        includeSelectAllOption: true
+                                    });
+                                });
+                            </script>
+                            <select id="example-enableClickableOptGroups-disabled" multiple="multiple">
+                                <optgroup label="Group 1">
+                                    <option value="1-1" disabled>Option 1.1</option>
+                                    <option value="1-2" selected="selected">Option 1.2</option>
+                                    <option value="1-3" selected="selected">Option 1.3</option>
+                                </optgroup>
+                                <optgroup label="Group 2">
+                                    <option value="2-1" disabled>Option 2.1</option>
+                                    <option value="2-2">Option 2.2</option>
+                                    <option value="2-3">Option 2.3</option>
+                                </optgroup>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -533,37 +581,39 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        Note that the behavior of <code>onChange</code> changes. Whenever an optgroup is changed/clicked, the <code>onChange</code> event is fired with all affected options as first parameter.
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-enableClickableOptGroups-onChange').multiselect({
-                                                    enableClickableOptGroups: true,
-                                                    onChange: function(option, checked) {
-                                                        alert(option.length + ' options ' + (checked ? 'selected' : 'deselected'));
-                                                    }
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-enableClickableOptGroups-onChange" multiple="multiple">
-                                            <optgroup label="Group 1">
-                                                <option value="1-1">Option 1.1</option>
-                                                <option value="1-2" selected="selected">Option 1.2</option>
-                                                <option value="1-3" selected="selected">Option 1.3</option>
-                                            </optgroup>
-                                            <optgroup label="Group 2">
-                                                <option value="2-1">Option 2.1</option>
-                                                <option value="2-2">Option 2.2</option>
-                                                <option value="2-3">Option 2.3</option>
-                                            </optgroup>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+
+                        <p>
+                            Note that the behavior of <code>onChange</code> changes. Whenever an optgroup is
+                            changed/clicked, the <code>onChange</code> event is fired with all affected options as first
+                            parameter.
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-enableClickableOptGroups-onChange').multiselect({
+                                        enableClickableOptGroups: true,
+                                        onChange: function (option, checked) {
+                                            alert(option.length + ' options ' + (checked ? 'selected' : 'deselected'));
+                                        }
+                                    });
+                                });
+                            </script>
+                            <select id="example-enableClickableOptGroups-onChange" multiple="multiple">
+                                <optgroup label="Group 1">
+                                    <option value="1-1">Option 1.1</option>
+                                    <option value="1-2" selected="selected">Option 1.2</option>
+                                    <option value="1-3" selected="selected">Option 1.3</option>
+                                </optgroup>
+                                <optgroup label="Group 2">
+                                    <option value="2-1">Option 2.1</option>
+                                    <option value="2-2">Option 2.2</option>
+                                    <option value="2-3">Option 2.3</option>
+                                </optgroup>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -576,38 +626,39 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-enableCollapsibleOptGroups">enableCollapsibleOptGroups</code></td>
-                                <td>
-                                    <p>
-                                        If set to <code>true</code>, <code>optgroup</code>'s will be collapsible.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-enableCollapsibleOptGroups">enableCollapsibleOptGroups</code>
+                    </td>
+                    <td>
+                        <p>
+                            If set to <code>true</code>, <code>optgroup</code>'s will be collapsible.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-enableCollapsibleOptGroups').multiselect({
-                                                    enableCollapsibleOptGroups: true
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-enableCollapsibleOptGroups" multiple="multiple">
-                                            <optgroup label="Group 1">
-                                                <option value="1-1" disabled>Option 1.1</option>
-                                                <option value="1-2" selected="selected">Option 1.2</option>
-                                                <option value="1-3" selected="selected">Option 1.3</option>
-                                            </optgroup>
-                                            <optgroup label="Group 2">
-                                                <option value="2-1">Option 2.1</option>
-                                                <option value="2-2">Option 2.2</option>
-                                                <option value="2-3">Option 2.3</option>
-                                            </optgroup>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-enableCollapsibleOptGroups').multiselect({
+                                        enableCollapsibleOptGroups: true
+                                    });
+                                });
+                            </script>
+                            <select id="example-enableCollapsibleOptGroups" multiple="multiple">
+                                <optgroup label="Group 1">
+                                    <option value="1-1" disabled>Option 1.1</option>
+                                    <option value="1-2" selected="selected">Option 1.2</option>
+                                    <option value="1-3" selected="selected">Option 1.3</option>
+                                </optgroup>
+                                <optgroup label="Group 2">
+                                    <option value="2-1">Option 2.1</option>
+                                    <option value="2-2">Option 2.2</option>
+                                    <option value="2-3">Option 2.3</option>
+                                </optgroup>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -617,27 +668,27 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-disableIfEmpty">disableIfEmpty</code></td>
-                                <td>
-                                    <p>
-                                        If set to <code>true</code>, the multiselect will be disabled if no options are given.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-disableIfEmpty">disableIfEmpty</code></td>
+                    <td>
+                        <p>
+                            If set to <code>true</code>, the multiselect will be disabled if no options are given.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-disableIfEmpty').multiselect({
-                                                    disableIfEmpty: true
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-disableIfEmpty" multiple="multiple"></select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-disableIfEmpty').multiselect({
+                                        disableIfEmpty: true
+                                    });
+                                });
+                            </script>
+                            <select id="example-disableIfEmpty" multiple="multiple"></select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -647,28 +698,30 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-disabledText">disabledText</code></td>
-                                <td>
-                                    <p>
-                                        The text shown if the multiselect is disabled. Note that this option is set to the empty string <code>''</code> by default, that is <code>nonSelectedText</code> is shown if the multiselect is disabled and no options are selected.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-disabledText">disabledText</code></td>
+                    <td>
+                        <p>
+                            The text shown if the multiselect is disabled. Note that this option is set to the empty
+                            string <code>''</code> by default, that is <code>nonSelectedText</code> is shown if the
+                            multiselect is disabled and no options are selected.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-disabledText').multiselect({
-                                                    disableIfEmpty: true,
-                                                    disabledText: 'Disabled ...'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-disabledText" multiple="multiple"></select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-disabledText').multiselect({
+                                        disableIfEmpty: true,
+                                        disabledText: 'Disabled ...'
+                                    });
+                                });
+                            </script>
+                            <select id="example-disabledText" multiple="multiple"></select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -679,30 +732,31 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        The <code>disabledText</code> option does also work when the underlying <code>select</code> is disabled:
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-disabledText-disabled').multiselect({
-                                                    disabledText: 'Disabled ...'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-disabledText-disabled" multiple="multiple" disabled="disabled">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+
+                        <p>
+                            The <code>disabledText</code> option does also work when the underlying <code>select</code>
+                            is disabled:
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-disabledText-disabled').multiselect({
+                                        disabledText: 'Disabled ...'
+                                    });
+                                });
+                            </script>
+                            <select id="example-disabledText-disabled" multiple="multiple" disabled="disabled">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -720,30 +774,30 @@
     &lt;option value=&quot;6&quot;&gt;Option 6&lt;/option&gt;
 &lt;/select&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        Note that selected options will still be shown:
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-disabledText-disabled-selected').multiselect({
-                                                    disabledText: 'Disabled ...'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-disabledText-disabled-selected" multiple="multiple" disabled="disabled">
-                                            <option value="1">Option 1</option>
-                                            <option value="2" selected="selected">Option 2</option>
-                                            <option value="3" selected="selected">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+
+                        <p>
+                            Note that selected options will still be shown:
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-disabledText-disabled-selected').multiselect({
+                                        disabledText: 'Disabled ...'
+                                    });
+                                });
+                            </script>
+                            <select id="example-disabledText-disabled-selected" multiple="multiple" disabled="disabled">
+                                <option value="1">Option 1</option>
+                                <option value="2" selected="selected">Option 2</option>
+                                <option value="3" selected="selected">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -761,35 +815,35 @@
     &lt;option value=&quot;6&quot;&gt;Option 6&lt;/option&gt;
 &lt;/select&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-dropRight">dropRight</code></td>
-                                <td>
-                                    <p>
-                                        The dropdown can also be dropped right.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-dropRight">dropRight</code></td>
+                    <td>
+                        <p>
+                            The dropdown can also be dropped right.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-dropRight').multiselect({
-                                                    buttonWidth: '400px',
-                                                    dropRight: true
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-dropRight" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-dropRight').multiselect({
+                                        buttonWidth: '400px',
+                                        dropRight: true
+                                    });
+                                });
+                            </script>
+                            <select id="example-dropRight" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -800,42 +854,46 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-dropUp">dropUp</code></td>
-                                <td>
-                                    <p>
-                                        The dropdown can also be dropped up. Note that it is recommended to also set <code>maxHeight</code>. The plugin calculates the necessary height of the dropdown and takes the minimum of the calculated value and <code>maxHeight</code>.
-                                    </p>
-                                    
-                                    <p class="alert alert-warning">
-                                        Note that this feature has been introduced in <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/594">#594</a> and is known to have issues depending on the environment.
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-dropUp').multiselect({
-                                                    enableFiltering: true,
-                                                    includeSelectAllOption: true,
-                                                    maxHeight: 400,
-                                                    dropUp: true
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-dropUp" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option data-role="divider"></option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-dropUp">dropUp</code></td>
+                    <td>
+                        <p>
+                            The dropdown can also be dropped up. Note that it is recommended to also set
+                            <code>maxHeight</code>. The plugin calculates the necessary height of the dropdown and takes
+                            the minimum of the calculated value and <code>maxHeight</code>.
+                        </p>
+
+                        <p class="alert alert-warning">
+                            Note that this feature has been introduced in <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/594">#594</a> and is
+                            known to have issues depending on the environment.
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-dropUp').multiselect({
+                                        enableFiltering: true,
+                                        includeSelectAllOption: true,
+                                        maxHeight: 400,
+                                        dropUp: true
+                                    });
+                                });
+                            </script>
+                            <select id="example-dropUp" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option data-role="divider"></option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -857,78 +915,80 @@
     &lt;option value=&quot;6&quot;&gt;Option 6&lt;/option&gt;
 &lt;/select&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-maxHeight">maxHeight</code></td>
-                                <td>
-                                    <p>
-                                        The maximum height of the dropdown. This is useful when using the plugin with plenty of options.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-maxHeight">maxHeight</code></td>
+                    <td>
+                        <p>
+                            The maximum height of the dropdown. This is useful when using the plugin with plenty of
+                            options.
+                        </p>
 
-                                    <div class="example">
-                                        <p>
-                                            The multiselect on the left uses <code>maxHeight</code> set to <code>200</code>. On the other hand, the multiselect on the right does not use <code>maxHeight</code>.
-                                        </p>
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-with-maxHeight').multiselect({
-                                                    maxHeight: 200
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-with-maxHeight" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                            <option value="7">Option 7</option>
-                                            <option value="9">Option 8</option>
-                                            <option value="9">Option 9</option>
-                                            <option value="10">Option 10</option>
-                                            <option value="11">Option 11</option>
-                                            <option value="12">Option 12</option>
-                                            <option value="13">Option 13</option>
-                                            <option value="14">Option 14</option>
-                                            <option value="15">Option 15</option>
-                                            <option value="16">Option 16</option>
-                                            <option value="17">Option 17</option>
-                                            <option value="18">Option 18</option>
-                                            <option value="19">Option 19</option>
-                                            <option value="20">Option 20</option>
-                                        </select>
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-without-maxHeight').multiselect();
-                                            });
-                                        </script>
-                                        <select id="example-without-maxHeight" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                            <option value="7">Option 7</option>
-                                            <option value="9">Option 8</option>
-                                            <option value="9">Option 9</option>
-                                            <option value="10">Option 10</option>
-                                            <option value="11">Option 11</option>
-                                            <option value="12">Option 12</option>
-                                            <option value="13">Option 13</option>
-                                            <option value="14">Option 14</option>
-                                            <option value="15">Option 15</option>
-                                            <option value="16">Option 16</option>
-                                            <option value="17">Option 17</option>
-                                            <option value="18">Option 18</option>
-                                            <option value="19">Option 19</option>
-                                            <option value="20">Option 20</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <p>
+                                The multiselect on the left uses <code>maxHeight</code> set to <code>200</code>. On the
+                                other hand, the multiselect on the right does not use <code>maxHeight</code>.
+                            </p>
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-with-maxHeight').multiselect({
+                                        maxHeight: 200
+                                    });
+                                });
+                            </script>
+                            <select id="example-with-maxHeight" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                                <option value="7">Option 7</option>
+                                <option value="9">Option 8</option>
+                                <option value="9">Option 9</option>
+                                <option value="10">Option 10</option>
+                                <option value="11">Option 11</option>
+                                <option value="12">Option 12</option>
+                                <option value="13">Option 13</option>
+                                <option value="14">Option 14</option>
+                                <option value="15">Option 15</option>
+                                <option value="16">Option 16</option>
+                                <option value="17">Option 17</option>
+                                <option value="18">Option 18</option>
+                                <option value="19">Option 19</option>
+                                <option value="20">Option 20</option>
+                            </select>
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-without-maxHeight').multiselect();
+                                });
+                            </script>
+                            <select id="example-without-maxHeight" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                                <option value="7">Option 7</option>
+                                <option value="9">Option 8</option>
+                                <option value="9">Option 9</option>
+                                <option value="10">Option 10</option>
+                                <option value="11">Option 11</option>
+                                <option value="12">Option 12</option>
+                                <option value="13">Option 13</option>
+                                <option value="14">Option 14</option>
+                                <option value="15">Option 15</option>
+                                <option value="16">Option 16</option>
+                                <option value="17">Option 17</option>
+                                <option value="18">Option 18</option>
+                                <option value="19">Option 19</option>
+                                <option value="20">Option 20</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -938,34 +998,35 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-checkboxName">checkboxName</code></td>
-                                <td>
-                                    <p>
-                                        The name used for the generated checkboxes. See <a href="#post">Server-Side Processing</a> for details.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-checkboxName">checkboxName</code></td>
+                    <td>
+                        <p>
+                            The name used for the generated checkboxes. See <a href="#post">Server-Side Processing</a>
+                            for details.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-checkboxName').multiselect({
-                                                    checkboxName: 'multiselect[]'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-checkboxName" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-checkboxName').multiselect({
+                                        checkboxName: 'multiselect[]'
+                                    });
+                                });
+                            </script>
+                            <select id="example-checkboxName" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -975,40 +1036,43 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-onChange">onChange</code></td>
-                                <td>
-                                    <p>
-                                        A function which is triggered on the change event of the options. Note that the event is not triggered when selecting or deselecting options using the <code>select</code> and <code>deselect</code> methods provided by the plugin.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-onChange">onChange</code></td>
+                    <td>
+                        <p>
+                            A function which is triggered on the change event of the options. Note that the event is not
+                            triggered when selecting or deselecting options using the <code>select</code> and <code>deselect</code>
+                            methods provided by the plugin.
+                        </p>
 
-                                    <p class="alert alert-warning">
-                                        Note that the behavior of <code>onChange</code> changes when setting <code>enableClickableOptGroups</code> to <code>true</code>.
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-onChange').multiselect({
-                                                    onChange: function(option, checked, select) {
-                                                        alert('Changed option ' + $(option).val() + '.');
-                                                    }
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-onChange" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <p class="alert alert-warning">
+                            Note that the behavior of <code>onChange</code> changes when setting <code>enableClickableOptGroups</code>
+                            to <code>true</code>.
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-onChange').multiselect({
+                                        onChange: function (option, checked, select) {
+                                            alert('Changed option ' + $(option).val() + '.');
+                                        }
+                                    });
+                                });
+                            </script>
+                            <select id="example-onChange" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1020,41 +1084,41 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-onInitialized">onInitialized</code></td>
-                                <td>
-                                    <p>
-                                        A function which is triggered when the multiselect is finished initializing.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-onInitialized">onInitialized</code></td>
+                    <td>
+                        <p>
+                            A function which is triggered when the multiselect is finished initializing.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-onInitialized-button').on('click', function() {
-                                                    $('#example-onInitialized').multiselect({
-                                                        onInitialized: function(select, container) {
-                                                            alert('Initialized.');
-                                                        }
-                                                    });
-                                                });
-                                            });
-                                        </script>
-                                        <div class="btn-group">
-                                            <select id="example-onInitialized" multiple="multiple">
-                                                <option value="1">Option 1</option>
-                                                <option value="2">Option 2</option>
-                                                <option value="3">Option 3</option>
-                                                <option value="4">Option 4</option>
-                                                <option value="5">Option 5</option>
-                                                <option value="6">Option 6</option>
-                                            </select>
-                                            <button id="example-onInitialized-button" class="btn btn-primary">Activate!</button>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-onInitialized-button').on('click', function () {
+                                        $('#example-onInitialized').multiselect({
+                                            onInitialized: function (select, container) {
+                                                alert('Initialized.');
+                                            }
+                                        });
+                                    });
+                                });
+                            </script>
+                            <div class="btn-group">
+                                <select id="example-onInitialized" multiple="multiple">
+                                    <option value="1">Option 1</option>
+                                    <option value="2">Option 2</option>
+                                    <option value="3">Option 3</option>
+                                    <option value="4">Option 4</option>
+                                    <option value="5">Option 5</option>
+                                    <option value="6">Option 6</option>
+                                </select>
+                                <button id="example-onInitialized-button" class="btn btn-primary">Activate!</button>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1079,40 +1143,40 @@
     &lt;button id=&quot;example-onInitialized-button&quot; class=&quot;btn btn-primary&quot;&gt;Activate!&lt;/button&gt;
 &lt;/div&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-onDropdownShow">onDropdownShow</code></td>
-                                <td>
-                                    <p>
-                                        A callback called when the dropdown is shown.
-                                    </p>
-                                    
-                                    <p class="alert alert-warning">
-                                        The <code>onDropdownShow</code> option is not available when using Twitter Bootstrap 2.3.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-onDropdownShow">onDropdownShow</code></td>
+                    <td>
+                        <p>
+                            A callback called when the dropdown is shown.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-onDropdownShow').multiselect({
-                                                    onDropdownShow: function(event) {
-                                                        alert('Dropdown shown.');
-                                                    }
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-onDropdownShow" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <p class="alert alert-warning">
+                            The <code>onDropdownShow</code> option is not available when using Twitter Bootstrap 2.3.
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-onDropdownShow').multiselect({
+                                        onDropdownShow: function (event) {
+                                            alert('Dropdown shown.');
+                                        }
+                                    });
+                                });
+                            </script>
+                            <select id="example-onDropdownShow" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1124,40 +1188,40 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-onDropdownHide">onDropdownHide</code></td>
-                                <td>
-                                    <p>
-                                        A callback called when the dropdown is closed.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-onDropdownHide">onDropdownHide</code></td>
+                    <td>
+                        <p>
+                            A callback called when the dropdown is closed.
+                        </p>
 
-                                    <p class="alert alert-warning">
-                                        The <code>onDropdownHide</code> option is not available when using Twitter Bootstrap 2.3.
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-onDropdownHide').multiselect({
-                                                    onDropdownHide: function(event) {
-                                                        alert('Dropdown closed.');
-                                                    }
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-onDropdownHide" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <p class="alert alert-warning">
+                            The <code>onDropdownHide</code> option is not available when using Twitter Bootstrap 2.3.
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-onDropdownHide').multiselect({
+                                        onDropdownHide: function (event) {
+                                            alert('Dropdown closed.');
+                                        }
+                                    });
+                                });
+                            </script>
+                            <select id="example-onDropdownHide" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1169,40 +1233,40 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-onDropdownShown">onDropdownShown</code></td>
-                                <td>
-                                    <p>
-                                        A callback called <i>after</i> the dropdown has been shown.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-onDropdownShown">onDropdownShown</code></td>
+                    <td>
+                        <p>
+                            A callback called <i>after</i> the dropdown has been shown.
+                        </p>
 
-                                    <p class="alert alert-warning">
-                                        The <code>onDropdownShown</code> option is not available when using Twitter Bootstrap 2.3.
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-onDropdownShown').multiselect({
-                                                    onDropdownShown: function(event) {
-                                                        alert('Dropdown shown.');
-                                                    }
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-onDropdownShown" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <p class="alert alert-warning">
+                            The <code>onDropdownShown</code> option is not available when using Twitter Bootstrap 2.3.
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-onDropdownShown').multiselect({
+                                        onDropdownShown: function (event) {
+                                            alert('Dropdown shown.');
+                                        }
+                                    });
+                                });
+                            </script>
+                            <select id="example-onDropdownShown" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1214,40 +1278,40 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-onDropdownHidden">onDropdownHidden</code></td>
-                                <td>
-                                    <p>
-                                        A callback called <i>after</i> the dropdown has been closed.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-onDropdownHidden">onDropdownHidden</code></td>
+                    <td>
+                        <p>
+                            A callback called <i>after</i> the dropdown has been closed.
+                        </p>
 
-                                    <p class="alert alert-warning">
-                                        The <code>onDropdownHidden</code> option is not available when using Twitter Bootstrap 2.3.
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-onDropdownHidden').multiselect({
-                                                    onDropdownHidden: function(event) {
-                                                        alert('Dropdown closed.');
-                                                    }
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-onDropdownHidden" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <p class="alert alert-warning">
+                            The <code>onDropdownHidden</code> option is not available when using Twitter Bootstrap 2.3.
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-onDropdownHidden').multiselect({
+                                        onDropdownHidden: function (event) {
+                                            alert('Dropdown closed.');
+                                        }
+                                    });
+                                });
+                            </script>
+                            <select id="example-onDropdownHidden" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1259,34 +1323,34 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-buttonClass">buttonClass</code></td>
-                                <td>
-                                    <p>
-                                        The class of the multiselect button.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-buttonClass">buttonClass</code></td>
+                    <td>
+                        <p>
+                            The class of the multiselect button.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-buttonClass').multiselect({
-                                                    buttonClass: 'btn btn-link'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-buttonClass" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-buttonClass').multiselect({
+                                        buttonClass: 'btn btn-link'
+                                    });
+                                });
+                            </script>
+                            <select id="example-buttonClass" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1296,34 +1360,34 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-inheritClass">inheritClass</code></td>
-                                <td>
-                                    <p>
-                                        Inherit the class of the button from the original select.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-inheritClass">inheritClass</code></td>
+                    <td>
+                        <p>
+                            Inherit the class of the button from the original select.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-inheritButton').multiselect({
-                                                    inheritClass: true
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-inheritButton" class="btn-primary" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-inheritButton').multiselect({
+                                        inheritClass: true
+                                    });
+                                });
+                            </script>
+                            <select id="example-inheritButton" class="btn-primary" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1333,34 +1397,34 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-buttonContainer">buttonContainer</code></td>
-                                <td>
-                                    <p>
-                                        The container holding both the button as well as the dropdown.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-buttonContainer">buttonContainer</code></td>
+                    <td>
+                        <p>
+                            The container holding both the button as well as the dropdown.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-buttonContainer').multiselect({
-                                                    buttonContainer: '<div class="btn-group" />'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-buttonContainer" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-buttonContainer').multiselect({
+                                        buttonContainer: '<div class="btn-group" />'
+                                    });
+                                });
+                            </script>
+                            <select id="example-buttonContainer" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1370,34 +1434,34 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-buttonWidth">buttonWidth</code></td>
-                                <td>
-                                    <p>
-                                        The width of the multiselect button may be fixed using this option.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-buttonWidth">buttonWidth</code></td>
+                    <td>
+                        <p>
+                            The width of the multiselect button may be fixed using this option.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-buttonWidth').multiselect({
-                                                    buttonWidth: '400px'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-buttonWidth" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-buttonWidth').multiselect({
+                                        buttonWidth: '400px'
+                                    });
+                                });
+                            </script>
+                            <select id="example-buttonWidth" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1407,28 +1471,29 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>Note that if the text in the button title is too long, it will be truncated and use an ellipsis</p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-buttonWidth-overflow').multiselect({
-                                                    buttonWidth: '150px'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-buttonWidth-overflow" multiple="multiple">
-                                            <option value="1" selected>Option 1</option>
-                                            <option value="2" selected>Option 2</option>
-                                            <option value="3" selected>Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+
+                        <p>Note that if the text in the button title is too long, it will be truncated and use an
+                            ellipsis</p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-buttonWidth-overflow').multiselect({
+                                        buttonWidth: '150px'
+                                    });
+                                });
+                            </script>
+                            <select id="example-buttonWidth-overflow" multiple="multiple">
+                                <option value="1" selected>Option 1</option>
+                                <option value="2" selected>Option 2</option>
+                                <option value="3" selected>Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1438,28 +1503,28 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        This does also work for long options:
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-buttonWidth-overflow-option').multiselect({
-                                                    buttonWidth: '150px'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-buttonWidth-overflow-option" multiple="multiple">
-                                            <option value="1" selected>Long Long Long Option 1</option>
-                                            <option value="2">Very Very Long Option 2</option>
-                                            <option value="3">Even Longer Option 3</option>
-                                            <option value="4">Ridiculous Long Option 4</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+
+                        <p>
+                            This does also work for long options:
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-buttonWidth-overflow-option').multiselect({
+                                        buttonWidth: '150px'
+                                    });
+                                });
+                            </script>
+                            <select id="example-buttonWidth-overflow-option" multiple="multiple">
+                                <option value="1" selected>Long Long Long Option 1</option>
+                                <option value="2">Very Very Long Option 2</option>
+                                <option value="3">Even Longer Option 3</option>
+                                <option value="4">Ridiculous Long Option 4</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1469,57 +1534,62 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-buttonText">buttonText</code></td>
-                                <td>
-                                    <p>
-                                        A callback specifying the text shown on the button dependent on the currently selected options.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-buttonText">buttonText</code></td>
+                    <td>
+                        <p>
+                            A callback specifying the text shown on the button dependent on the currently selected
+                            options.
+                        </p>
 
-                                    <p>
-                                        The callback gets the currently selected <code>options</code> and the <code>select</code> as argument and returns the string shown as button text. The default <code>buttonText</code> callback returns <code>nonSelectedText</code> in the case no option is selected, <code>nSelectedText</code> in the case more than <code>numberDisplayed</code> options are selected and the names of the selected options if less than <code>numberDisplayed</code> options are selected.
-                                    </p>
+                        <p>
+                            The callback gets the currently selected <code>options</code> and the <code>select</code> as
+                            argument and returns the string shown as button text. The default <code>buttonText</code>
+                            callback returns <code>nonSelectedText</code> in the case no option is selected, <code>nSelectedText</code>
+                            in the case more than <code>numberDisplayed</code> options are selected and the names of the
+                            selected options if less than <code>numberDisplayed</code> options are selected.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-buttonText').multiselect({
-                                                    buttonText: function(options, select) {
-                                                        if (options.length === 0) {
-                                                            return 'No option selected ...';
-                                                        }
-                                                        else if (options.length > 3) {
-                                                            return 'More than 3 options selected!';
-                                                        }
-                                                         else {
-                                                             var labels = [];
-                                                             options.each(function() {
-                                                                 if ($(this).attr('label') !== undefined) {
-                                                                     labels.push($(this).attr('label'));
-                                                                 }
-                                                                 else {
-                                                                     labels.push($(this).html());
-                                                                 }
-                                                             });
-                                                             return labels.join(', ');
-                                                         }
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-buttonText').multiselect({
+                                        buttonText: function (options, select) {
+                                            if (options.length === 0) {
+                                                return 'No option selected ...';
+                                            }
+                                            else if (options.length > 3) {
+                                                return 'More than 3 options selected!';
+                                            }
+                                            else {
+                                                var labels = [];
+                                                options.each(function () {
+                                                    if ($(this).attr('label') !== undefined) {
+                                                        labels.push($(this).attr('label'));
+                                                    }
+                                                    else {
+                                                        labels.push($(this).html());
                                                     }
                                                 });
-                                            });
-                                        </script>
-                                        <select id="example-buttonText" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                                                return labels.join(', ');
+                                            }
+                                        }
+                                    });
+                                });
+                            </script>
+                            <select id="example-buttonText" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1548,47 +1618,52 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-buttonTitle">buttonTitle</code></td>
-                                <td>
-                                    <p>
-                                        A callback specifying the title of the button.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-buttonTitle">buttonTitle</code></td>
+                    <td>
+                        <p>
+                            A callback specifying the title of the button.
+                        </p>
 
-                                    <p>
-                                        The callback gets the currently selected <code>options</code> and the <code>select</code> as argument and returns the title of the button as string. The default <code>buttonTitle</code> callback returns <code>nonSelectedText</code> in the case no option is selected and the names of the selected options of less than <code>numberDisplayed</code> options are selected. If more than <code>numberDisplayed</code> options are selected, <code>nSelectedText</code> is returned.
-                                    </p>
+                        <p>
+                            The callback gets the currently selected <code>options</code> and the <code>select</code> as
+                            argument and returns the title of the button as string. The default <code>buttonTitle</code>
+                            callback returns <code>nonSelectedText</code> in the case no option is selected and the
+                            names of the selected options of less than <code>numberDisplayed</code> options are
+                            selected. If more than <code>numberDisplayed</code> options are selected, <code>nSelectedText</code>
+                            is returned.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-buttonTitle').multiselect({
-                                                    buttonText: function(options, select) {
-                                                        return 'Check the title!';
-                                                    },
-                                                    buttonTitle: function(options, select) {
-                                                        var labels = [];
-                                                        options.each(function () {
-                                                            labels.push($(this).text());
-                                                        });
-                                                        return labels.join(' - ');
-                                                    }
-                                                });
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-buttonTitle').multiselect({
+                                        buttonText: function (options, select) {
+                                            return 'Check the title!';
+                                        },
+                                        buttonTitle: function (options, select) {
+                                            var labels = [];
+                                            options.each(function () {
+                                                labels.push($(this).text());
                                             });
-                                        </script>
-                                        <select id="example-buttonTitle" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                                            return labels.join(' - ');
+                                        }
+                                    });
+                                });
+                            </script>
+                            <select id="example-buttonTitle" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1607,34 +1682,35 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-nonSelectedText">nonSelectedText</code></td>
-                                <td>
-                                    <p>
-                                        The text displayed when no option is selected. This option is used in the default <code>buttonText</code> and <code>buttonTitle</code> functions.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-nonSelectedText">nonSelectedText</code></td>
+                    <td>
+                        <p>
+                            The text displayed when no option is selected. This option is used in the default <code>buttonText</code>
+                            and <code>buttonTitle</code> functions.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-nonSelectedText').multiselect({
-                                                    nonSelectedText: 'Check an option!'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-nonSelectedText" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-nonSelectedText').multiselect({
+                                        nonSelectedText: 'Check an option!'
+                                    });
+                                });
+                            </script>
+                            <select id="example-nonSelectedText" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1644,34 +1720,36 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-nSelectedText">nSelectedText</code></td>
-                                <td>
-                                    <p>
-                                        The text displayed if more than <code>numberDisplayed</code> options are selected. This option is used by the default <code>buttonText</code> and <code>buttonTitle</code> callbacks.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-nSelectedText">nSelectedText</code></td>
+                    <td>
+                        <p>
+                            The text displayed if more than <code>numberDisplayed</code> options are selected. This
+                            option is used by the default <code>buttonText</code> and <code>buttonTitle</code>
+                            callbacks.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-nSelectedText').multiselect({
-                                                    nSelectedText: ' - Too many options selected!'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-nSelectedText" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-nSelectedText').multiselect({
+                                        nSelectedText: ' - Too many options selected!'
+                                    });
+                                });
+                            </script>
+                            <select id="example-nSelectedText" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1681,34 +1759,34 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-allSelectedText">allSelectedText</code></td>
-                                <td>
-                                    <p>
-                                        The text displayed if all options are selected.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-allSelectedText">allSelectedText</code></td>
+                    <td>
+                        <p>
+                            The text displayed if all options are selected.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-allSelectedText').multiselect({
-                                                    allSelectedText: 'No option left ...'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-allSelectedText" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-allSelectedText').multiselect({
+                                        allSelectedText: 'No option left ...'
+                                    });
+                                });
+                            </script>
+                            <select id="example-allSelectedText" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1718,31 +1796,31 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        This option may be useful in combination with the <code>includeSelectAllOption</code>:
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-allSelectedText-includeSelectAllOption').multiselect({
-                                                    includeSelectAllOption: true,
-                                                    allSelectedText: 'No option left ...'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-allSelectedText-includeSelectAllOption" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+
+                        <p>
+                            This option may be useful in combination with the <code>includeSelectAllOption</code>:
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-allSelectedText-includeSelectAllOption').multiselect({
+                                        includeSelectAllOption: true,
+                                        allSelectedText: 'No option left ...'
+                                    });
+                                });
+                            </script>
+                            <select id="example-allSelectedText-includeSelectAllOption" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1753,26 +1831,26 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        Note that the <code>allSelectedText</code> is not shown if only one option is available.
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-allSelectedText-allSelectedText-single').multiselect({
-                                                    includeSelectAllOption: true,
-                                                    allSelectedText: 'No option left ...'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-allSelectedText-allSelectedText-single" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+
+                        <p>
+                            Note that the <code>allSelectedText</code> is not shown if only one option is available.
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-allSelectedText-allSelectedText-single').multiselect({
+                                        includeSelectAllOption: true,
+                                        allSelectedText: 'No option left ...'
+                                    });
+                                });
+                            </script>
+                            <select id="example-allSelectedText-allSelectedText-single" multiple="multiple">
+                                <option value="1">Option 1</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1783,34 +1861,35 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-numberDisplayed">numberDisplayed</code></td>
-                                <td>
-                                    <p>
-                                        This option is used by the <code>buttonText</code> and <code>buttonTitle</code> functions to determine of too much options would be displayed.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-numberDisplayed">numberDisplayed</code></td>
+                    <td>
+                        <p>
+                            This option is used by the <code>buttonText</code> and <code>buttonTitle</code> functions to
+                            determine of too much options would be displayed.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-numberDisplayed').multiselect({
-                                                    numberDisplayed: 1
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-numberDisplayed" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-numberDisplayed').multiselect({
+                                        numberDisplayed: 1
+                                    });
+                                });
+                            </script>
+                            <select id="example-numberDisplayed" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1820,34 +1899,35 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-delimiterText">delimiterText</code></td>
-                                <td>
-                                    <p>
-                                        Sets the separator for the list of selected items for mouse-over. Defaults to ', '. Set to '\n' for a neater display.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-delimiterText">delimiterText</code></td>
+                    <td>
+                        <p>
+                            Sets the separator for the list of selected items for mouse-over. Defaults to ', '. Set to
+                            '\n' for a neater display.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-delimiterText').multiselect({
-                                                    delimiterText: '; '
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-delimiterText" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2" selected="selected">Option 2</option>
-                                            <option value="3" selected="selected">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-delimiterText').multiselect({
+                                        delimiterText: '; '
+                                    });
+                                });
+                            </script>
+                            <select id="example-delimiterText" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2" selected="selected">Option 2</option>
+                                <option value="3" selected="selected">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1857,36 +1937,36 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-optionLabel">optionLabel</code></td>
-                                <td>
-                                    <p>
-                                        A callback used to define the labels of the options.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-optionLabel">optionLabel</code></td>
+                    <td>
+                        <p>
+                            A callback used to define the labels of the options.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-optionLabel').multiselect({
-                                                    optionLabel: function(element) {
-                                                        return $(element).html() + ' (' + $(element).val() + ')';
-                                                    }
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-optionLabel" multiple="multiple">
-                                            <option value="option-1">Option 1</option>
-                                            <option value="option-2">Option 2</option>
-                                            <option value="option-3">Option 3</option>
-                                            <option value="option-4">Option 4</option>
-                                            <option value="option-5">Option 5</option>
-                                            <option value="option-6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-optionLabel').multiselect({
+                                        optionLabel: function (element) {
+                                            return $(element).html() + ' (' + $(element).val() + ')';
+                                        }
+                                    });
+                                });
+                            </script>
+                            <select id="example-optionLabel" multiple="multiple">
+                                <option value="option-1">Option 1</option>
+                                <option value="option-2">Option 2</option>
+                                <option value="option-3">Option 3</option>
+                                <option value="option-4">Option 4</option>
+                                <option value="option-5">Option 5</option>
+                                <option value="option-6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1906,50 +1986,51 @@
     &lt;option value=&quot;option-6&quot;&gt;Option 6&lt;/option&gt;
 &lt;/select&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-optionClass">optionClass</code></td>
-                                <td>
-                                    <p>
-                                        A callback used to define the classes for the <code>li</code> elements containing checkboxes and labels.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-optionClass">optionClass</code></td>
+                    <td>
+                        <p>
+                            A callback used to define the classes for the <code>li</code> elements containing checkboxes
+                            and labels.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-optionClass').multiselect({
-                                                    optionClass: function(element) {
-                                                        var value = $(element).val();
-                                                        
-                                                        if (value%2 == 0) {
-                                                            return 'even';
-                                                        }
-                                                        else {
-                                                            return 'odd';
-                                                        }
-                                                    }
-                                                });
-                                            });
-                                        </script>
-                                        <style type="text/css">
-                                            #example-optionClass-container .multiselect-container li.odd {
-                                                background: #eeeeee;
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-optionClass').multiselect({
+                                        optionClass: function (element) {
+                                            var value = $(element).val();
+
+                                            if (value % 2 == 0) {
+                                                return 'even';
                                             }
-                                        </style>
-                                        <div id="example-optionClass-container">
-                                            <select id="example-optionClass" multiple="multiple">
-                                                <option value="1">Option 1</option>
-                                                <option value="2">Option 2</option>
-                                                <option value="3">Option 3</option>
-                                                <option value="4">Option 4</option>
-                                                <option value="5">Option 5</option>
-                                                <option value="6">Option 6</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                                            else {
+                                                return 'odd';
+                                            }
+                                        }
+                                    });
+                                });
+                            </script>
+                            <style type="text/css">
+                                #example-optionClass-container .multiselect-container li.odd {
+                                    background: #eeeeee;
+                                }
+                            </style>
+                            <div id="example-optionClass-container">
+                                <select id="example-optionClass" multiple="multiple">
+                                    <option value="1">Option 1</option>
+                                    <option value="2">Option 2</option>
+                                    <option value="3">Option 3</option>
+                                    <option value="4">Option 4</option>
+                                    <option value="5">Option 5</option>
+                                    <option value="6">Option 6</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -1983,40 +2064,40 @@
     &lt;/select&gt;
 &lt;/div&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><code id="configuration-options-selectedClass">selectedClass</code></td>
-                                <td>
-                                    <p>
-                                        The class(es) applied on selected options.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code id="configuration-options-selectedClass">selectedClass</code></td>
+                    <td>
+                        <p>
+                            The class(es) applied on selected options.
+                        </p>
 
-                                    <div class="example">
-                                        <style type="text/css">
-                                            #example-selectedClass-container li.multiselect-selected a label {
-                                                color: red;
-                                            }
-                                        </style>
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-selectedClass').multiselect({
-                                                    buttonContainer: '<div class="btn-group" id="example-selectedClass-container"></div>',
-                                                    selectedClass: 'active multiselect-selected'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-selectedClass" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <style type="text/css">
+                                #example-selectedClass-container li.multiselect-selected a label {
+                                    color: red;
+                                }
+                            </style>
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-selectedClass').multiselect({
+                                        buttonContainer: '<div class="btn-group" id="example-selectedClass-container"></div>',
+                                        selectedClass: 'active multiselect-selected'
+                                    });
+                                });
+                            </script>
+                            <select id="example-selectedClass" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;style type="text/css"&gt;
     #example-selectedClass-container li.multiselect-selected a label {
@@ -2032,40 +2113,41 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code id="configuration-options-includeSelectAllOption">includeSelectAllOption</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        Set to <code>true</code> or <code>false</code> to enable or disable the select all option.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code id="configuration-options-includeSelectAllOption">includeSelectAllOption</code>
+                    </td>
+                    <td>
+                        <p>
+                            Set to <code>true</code> or <code>false</code> to enable or disable the select all option.
+                        </p>
 
-                                    <p class="alert alert-info">
-                                        To see an example using both the select all option and the filter, see the documentation of the <code>enableFiltering</code> option.
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-includeSelectAllOption').multiselect({
-                                                    includeSelectAllOption: true
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-includeSelectAllOption" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <p class="alert alert-info">
+                            To see an example using both the select all option and the filter, see the documentation of
+                            the <code>enableFiltering</code> option.
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-includeSelectAllOption').multiselect({
+                                        includeSelectAllOption: true
+                                    });
+                                });
+                            </script>
+                            <select id="example-includeSelectAllOption" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2075,34 +2157,34 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        The <code>includeSelectAllOption</code> option can also be used in combination with <code>optgroup</code>'s.
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-includeSelectAllOption-optgroups').multiselect({
-                                                    includeSelectAllOption: true
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-includeSelectAllOption-optgroups" multiple="multiple">
-                                            <optgroup label="Group 1">
-                                                <option value="1-1">Option 1.1</option>
-                                                <option value="1-2" selected="selected">Option 1.2</option>
-                                                <option value="1-3" selected="selected">Option 1.3</option>
-                                            </optgroup>
-                                            <optgroup label="Group 2">
-                                                <option value="2-1">Option 2.1</option>
-                                                <option value="2-2">Option 2.2</option>
-                                                <option value="2-3">Option 2.3</option>
-                                            </optgroup>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+
+                        <p>
+                            The <code>includeSelectAllOption</code> option can also be used in combination with <code>optgroup</code>'s.
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-includeSelectAllOption-optgroups').multiselect({
+                                        includeSelectAllOption: true
+                                    });
+                                });
+                            </script>
+                            <select id="example-includeSelectAllOption-optgroups" multiple="multiple">
+                                <optgroup label="Group 1">
+                                    <option value="1-1">Option 1.1</option>
+                                    <option value="1-2" selected="selected">Option 1.2</option>
+                                    <option value="1-3" selected="selected">Option 1.3</option>
+                                </optgroup>
+                                <optgroup label="Group 2">
+                                    <option value="2-1">Option 2.1</option>
+                                    <option value="2-2">Option 2.2</option>
+                                    <option value="2-3">Option 2.3</option>
+                                </optgroup>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2112,33 +2194,34 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        Note that the select all does not trigger the <code>onChange</code> event and only triggers the <code>onSelectAll</code> event:
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-includeSelectAllOption-onChange').multiselect({
-                                                    includeSelectAllOption: true,
-                                                    onChange: function(option, checked) {
-                                                        alert('Not triggered when clicking the select all!');
-                                                    },
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-includeSelectAllOption-onChange" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+
+                        <p>
+                            Note that the select all does not trigger the <code>onChange</code> event and only triggers
+                            the <code>onSelectAll</code> event:
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-includeSelectAllOption-onChange').multiselect({
+                                        includeSelectAllOption: true,
+                                        onChange: function (option, checked) {
+                                            alert('Not triggered when clicking the select all!');
+                                        },
+                                    });
+                                });
+                            </script>
+                            <select id="example-includeSelectAllOption-onChange" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type="text/javascript"&gt;
     $(document).ready(function() {
@@ -2151,38 +2234,41 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code id="configuration-options-selectAllJustVisible">selectAllJustVisible</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        Setting both <code>includeSelectAllOption</code> and <code>enableFiltering</code> to <code>true</code>, the select all option does always select only the visible option. With setting <code>selectAllJustVisible</code> to <code>false</code> this behavior is changed such that always all options (irrespective of whether they are visible) are selected.
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-selectAllJustVisible').multiselect({
-                                                    enableFiltering: true,
-                                                    includeSelectAllOption: true,
-                                                    selectAllJustVisible: false
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-selectAllJustVisible" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code id="configuration-options-selectAllJustVisible">selectAllJustVisible</code>
+                    </td>
+                    <td>
+                        <p>
+                            Setting both <code>includeSelectAllOption</code> and <code>enableFiltering</code> to <code>true</code>,
+                            the select all option does always select only the visible option. With setting <code>selectAllJustVisible</code>
+                            to <code>false</code> this behavior is changed such that always all options (irrespective of
+                            whether they are visible) are selected.
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-selectAllJustVisible').multiselect({
+                                        enableFiltering: true,
+                                        includeSelectAllOption: true,
+                                        selectAllJustVisible: false
+                                    });
+                                });
+                            </script>
+                            <select id="example-selectAllJustVisible" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2194,37 +2280,37 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code id="configuration-options-selectAllText">selectAllText</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        The text displayed for the select all option.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code id="configuration-options-selectAllText">selectAllText</code>
+                    </td>
+                    <td>
+                        <p>
+                            The text displayed for the select all option.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-selectAllText').multiselect({
-                                                    includeSelectAllOption: true,
-                                                    selectAllText: 'Check all!'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-selectAllText" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-selectAllText').multiselect({
+                                        includeSelectAllOption: true,
+                                        selectAllText: 'Check all!'
+                                    });
+                                });
+                            </script>
+                            <select id="example-selectAllText" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2235,37 +2321,39 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code id="configuration-options-selectAllValue">selectAllValue</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        The select all option is added as additional <code>option</code> within the <code>select</code>. To distinguish this option from the original options the value used for the select all option can be configured using the <code>selectAllValue</code> option.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code id="configuration-options-selectAllValue">selectAllValue</code>
+                    </td>
+                    <td>
+                        <p>
+                            The select all option is added as additional <code>option</code> within the
+                            <code>select</code>. To distinguish this option from the original options the value used for
+                            the select all option can be configured using the <code>selectAllValue</code> option.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-selectAllValue').multiselect({
-                                                    includeSelectAllOption: true,
-                                                    selectAllValue: 'select-all-value'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-selectAllValue" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-selectAllValue').multiselect({
+                                        includeSelectAllOption: true,
+                                        selectAllValue: 'select-all-value'
+                                    });
+                                });
+                            </script>
+                            <select id="example-selectAllValue" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2276,29 +2364,30 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>The <code>selectAllValue</code> option should usually be a string, however, numeric values work as well:</p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-selectAllValue-numeric').multiselect({
-                                                    includeSelectAllOption: true,
-                                                    selectAllValue: 0
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-selectAllValue-numeric" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+
+                        <p>The <code>selectAllValue</code> option should usually be a string, however, numeric values
+                            work as well:</p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-selectAllValue-numeric').multiselect({
+                                        includeSelectAllOption: true,
+                                        selectAllValue: 0
+                                    });
+                                });
+                            </script>
+                            <select id="example-selectAllValue-numeric" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2309,37 +2398,38 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code id="configuration-options-selectAllName">selectAllName</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        This option allows to control the name given to the select all option. See <a href="#post">Server-Side Processing</a> for more details.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code id="configuration-options-selectAllName">selectAllName</code>
+                    </td>
+                    <td>
+                        <p>
+                            This option allows to control the name given to the select all option. See <a href="#post">Server-Side
+                            Processing</a> for more details.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-selectAllName').multiselect({
-                                                    includeSelectAllOption: true,
-                                                    selectAllName: 'select-all-name'
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-selectAllName" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-selectAllName').multiselect({
+                                        includeSelectAllOption: true,
+                                        selectAllName: 'select-all-name'
+                                    });
+                                });
+                            </script>
+                            <select id="example-selectAllName" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2350,37 +2440,39 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code id="configuration-options-selectAllNumber">selectAllNumber</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        If set to <code>true</code> (default), the number of selected options will be shown in parantheses when all options are seleted. The below example shows the behavior of the selectalloption with <code>selectAllNumber</code> set to <code>false</code>:
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code id="configuration-options-selectAllNumber">selectAllNumber</code>
+                    </td>
+                    <td>
+                        <p>
+                            If set to <code>true</code> (default), the number of selected options will be shown in
+                            parantheses when all options are seleted. The below example shows the behavior of the
+                            selectalloption with <code>selectAllNumber</code> set to <code>false</code>:
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-selectAllNumber').multiselect({
-                                                    includeSelectAllOption: true,
-                                                    selectAllNumber: false
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-selectAllNumber" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-selectAllNumber').multiselect({
+                                        includeSelectAllOption: true,
+                                        selectAllNumber: false
+                                    });
+                                });
+                            </script>
+                            <select id="example-selectAllNumber" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2391,39 +2483,41 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code id="configuration-options-onSelectAll">onSelectAll</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        This function is triggered when the select all option is used to select all options. Note that this can also be triggered manually using the <code>.multiselect('selectAll')</code> method.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code id="configuration-options-onSelectAll">onSelectAll</code>
+                    </td>
+                    <td>
+                        <p>
+                            This function is triggered when the select all option is used to select all options. Note
+                            that this can also be triggered manually using the <code>.multiselect('selectAll')</code>
+                            method.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-onSelectAll').multiselect({
-                                                    includeSelectAllOption: true,
-                                                    onSelectAll: function(checked) {
-                                                        alert('onSelectAll triggered: ' + (checked ? 'selected all' : 'deselected all') + '!');
-                                                    }
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-onSelectAll" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-onSelectAll').multiselect({
+                                        includeSelectAllOption: true,
+                                        onSelectAll: function (checked) {
+                                            alert('onSelectAll triggered: ' + (checked ? 'selected all' : 'deselected all') + '!');
+                                        }
+                                    });
+                                });
+                            </script>
+                            <select id="example-onSelectAll" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $('#example-onSelectAll').multiselect({
@@ -2434,45 +2528,46 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code id="configuration-options-enableFiltering">enableFiltering</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        Set to <code>true</code> or <code>false</code> to enable or disable the filter. A filter <code>input</code> will be added to dynamically filter all options.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code id="configuration-options-enableFiltering">enableFiltering</code>
+                    </td>
+                    <td>
+                        <p>
+                            Set to <code>true</code> or <code>false</code> to enable or disable the filter. A filter
+                            <code>input</code> will be added to dynamically filter all options.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-enableFiltering').multiselect({
-                                                    enableFiltering: true
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-enableFiltering" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                            <option value="7">Option 7</option>
-                                            <option value="8">Option 8</option>
-                                            <option value="9">Option 9</option>
-                                            <option value="10">Option 10</option>
-                                            <option value="11">Option 11</option>
-                                            <option value="12">Option 12</option>
-                                            <option value="13">Option 13</option>
-                                            <option value="14">Option 14</option>
-                                            <option value="15">Option 15</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-enableFiltering').multiselect({
+                                        enableFiltering: true
+                                    });
+                                });
+                            </script>
+                            <select id="example-enableFiltering" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                                <option value="7">Option 7</option>
+                                <option value="8">Option 8</option>
+                                <option value="9">Option 9</option>
+                                <option value="10">Option 10</option>
+                                <option value="11">Option 11</option>
+                                <option value="12">Option 12</option>
+                                <option value="13">Option 13</option>
+                                <option value="14">Option 14</option>
+                                <option value="15">Option 15</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2482,40 +2577,41 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        The <code>enableFiltering</code> option can easily be used in combination with the <code>includeSelectAllOption</code> option:
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-enableFiltering-includeSelectAllOption').multiselect({
-                                                    includeSelectAllOption: true,
-                                                    enableFiltering: true
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-enableFiltering-includeSelectAllOption" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                            <option value="7">Option 7</option>
-                                            <option value="8">Option 8</option>
-                                            <option value="9">Option 9</option>
-                                            <option value="10">Option 10</option>
-                                            <option value="11">Option 11</option>
-                                            <option value="12">Option 12</option>
-                                            <option value="13">Option 13</option>
-                                            <option value="14">Option 14</option>
-                                            <option value="15">Option 15</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+
+                        <p>
+                            The <code>enableFiltering</code> option can easily be used in combination with the <code>includeSelectAllOption</code>
+                            option:
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-enableFiltering-includeSelectAllOption').multiselect({
+                                        includeSelectAllOption: true,
+                                        enableFiltering: true
+                                    });
+                                });
+                            </script>
+                            <select id="example-enableFiltering-includeSelectAllOption" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                                <option value="7">Option 7</option>
+                                <option value="8">Option 8</option>
+                                <option value="9">Option 9</option>
+                                <option value="10">Option 10</option>
+                                <option value="11">Option 11</option>
+                                <option value="12">Option 12</option>
+                                <option value="13">Option 13</option>
+                                <option value="14">Option 14</option>
+                                <option value="15">Option 15</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2526,33 +2622,35 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        The <code>enableFiltering</code> option can also be used in combination with <code>optgroup</code>'s.
-                                    </p>
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-enableFiltering-optgroups').multiselect({
-                                                    enableFiltering: true
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-enableFiltering-optgroups" multiple="multiple">
-                                            <optgroup label="Group 1">
-                                                <option value="1-1">Option 1.1</option>
-                                                <option value="1-2" selected="selected">Option 1.2</option>
-                                                <option value="1-3" selected="selected">Option 1.3</option>
-                                            </optgroup>
-                                            <optgroup label="Group 2">
-                                                <option value="2-1">Option 2.1</option>
-                                                <option value="2-2">Option 2.2</option>
-                                                <option value="2-3">Option 2.3</option>
-                                            </optgroup>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+
+                        <p>
+                            The <code>enableFiltering</code> option can also be used in combination with
+                            <code>optgroup</code>'s.
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-enableFiltering-optgroups').multiselect({
+                                        enableFiltering: true
+                                    });
+                                });
+                            </script>
+                            <select id="example-enableFiltering-optgroups" multiple="multiple">
+                                <optgroup label="Group 1">
+                                    <option value="1-1">Option 1.1</option>
+                                    <option value="1-2" selected="selected">Option 1.2</option>
+                                    <option value="1-3" selected="selected">Option 1.3</option>
+                                </optgroup>
+                                <optgroup label="Group 2">
+                                    <option value="2-1">Option 2.1</option>
+                                    <option value="2-2">Option 2.2</option>
+                                    <option value="2-3">Option 2.3</option>
+                                </optgroup>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2562,34 +2660,35 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        Clickable <code>optgroup</code>'s are also supported:
-                                    </p>
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-enableFiltering-enableClickableOptGroups').multiselect({
-                                                    enableFiltering: true,
-                                                    enableClickableOptGroups: true
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-enableFiltering-enableClickableOptGroups" multiple="multiple">
-                                            <optgroup label="Group 1">
-                                                <option value="1-1">Option 1.1</option>
-                                                <option value="1-2" selected="selected">Option 1.2</option>
-                                                <option value="1-3" selected="selected">Option 1.3</option>
-                                            </optgroup>
-                                            <optgroup label="Group 2">
-                                                <option value="2-1">Option 2.1</option>
-                                                <option value="2-2">Option 2.2</option>
-                                                <option value="2-3">Option 2.3</option>
-                                            </optgroup>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+
+                        <p>
+                            Clickable <code>optgroup</code>'s are also supported:
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-enableFiltering-enableClickableOptGroups').multiselect({
+                                        enableFiltering: true,
+                                        enableClickableOptGroups: true
+                                    });
+                                });
+                            </script>
+                            <select id="example-enableFiltering-enableClickableOptGroups" multiple="multiple">
+                                <optgroup label="Group 1">
+                                    <option value="1-1">Option 1.1</option>
+                                    <option value="1-2" selected="selected">Option 1.2</option>
+                                    <option value="1-3" selected="selected">Option 1.3</option>
+                                </optgroup>
+                                <optgroup label="Group 2">
+                                    <option value="2-1">Option 2.1</option>
+                                    <option value="2-2">Option 2.2</option>
+                                    <option value="2-3">Option 2.3</option>
+                                </optgroup>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2600,44 +2699,45 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        Finally, the option can also be used together with <code>onChange</code> or similar events:
-                                    </p>
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-enableFiltering-onChange-onDropdownHide').multiselect({
-                                                    enableFiltering: true,
-                                                    onChange: function(option, checked) {
-                                                        alert('onChange!');
-                                                    },
-                                                    onDropdownHide: function(event) {
-                                                        alert('onDropdownHide!');
-                                                    }
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-enableFiltering-onChange-onDropdownHide" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                            <option value="7">Option 7</option>
-                                            <option value="8">Option 8</option>
-                                            <option value="9">Option 9</option>
-                                            <option value="10">Option 10</option>
-                                            <option value="11">Option 11</option>
-                                            <option value="12">Option 12</option>
-                                            <option value="13">Option 13</option>
-                                            <option value="14">Option 14</option>
-                                            <option value="15">Option 15</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        </div>
+
+                        <p>
+                            Finally, the option can also be used together with <code>onChange</code> or similar events:
+                        </p>
+
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-enableFiltering-onChange-onDropdownHide').multiselect({
+                                        enableFiltering: true,
+                                        onChange: function (option, checked) {
+                                            alert('onChange!');
+                                        },
+                                        onDropdownHide: function (event) {
+                                            alert('onDropdownHide!');
+                                        }
+                                    });
+                                });
+                            </script>
+                            <select id="example-enableFiltering-onChange-onDropdownHide" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                                <option value="7">Option 7</option>
+                                <option value="8">Option 8</option>
+                                <option value="9">Option 9</option>
+                                <option value="10">Option 10</option>
+                                <option value="11">Option 11</option>
+                                <option value="12">Option 12</option>
+                                <option value="13">Option 13</option>
+                                <option value="14">Option 14</option>
+                                <option value="15">Option 15</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2653,45 +2753,46 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code id="configuration-options-enableCaseInsensitiveFiltering">enableCaseInsensitiveFiltering</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        The filter as configured above will use case sensitive filtering, by setting <code>enableCaseInsensitiveFiltering</code> to <code>true</code> this behavior can be changed to use case insensitive filtering.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code id="configuration-options-enableCaseInsensitiveFiltering">enableCaseInsensitiveFiltering</code>
+                    </td>
+                    <td>
+                        <p>
+                            The filter as configured above will use case sensitive filtering, by setting <code>enableCaseInsensitiveFiltering</code>
+                            to <code>true</code> this behavior can be changed to use case insensitive filtering.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-enableCaseInsensitiveFiltering').multiselect({
-                                                    enableCaseInsensitiveFiltering: true
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-enableCaseInsensitiveFiltering" multiple="multiple">
-                                            <option value="1">OpTiOn 1</option>
-                                            <option value="2">OpTiOn 2</option>
-                                            <option value="3">OpTiOn 3</option>
-                                            <option value="4">OpTiOn 4</option>
-                                            <option value="5">OpTiOn 5</option>
-                                            <option value="6">OpTiOn 6</option>
-                                            <option value="7">OpTiOn 7</option>
-                                            <option value="8">OpTiOn 8</option>
-                                            <option value="9">OpTiOn 9</option>
-                                            <option value="10">OpTiOn 10</option>
-                                            <option value="11">OpTiOn 11</option>
-                                            <option value="12">OpTiOn 12</option>
-                                            <option value="13">OpTiOn 13</option>
-                                            <option value="14">OpTiOn 14</option>
-                                            <option value="15">OpTiOn 15</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-enableCaseInsensitiveFiltering').multiselect({
+                                        enableCaseInsensitiveFiltering: true
+                                    });
+                                });
+                            </script>
+                            <select id="example-enableCaseInsensitiveFiltering" multiple="multiple">
+                                <option value="1">OpTiOn 1</option>
+                                <option value="2">OpTiOn 2</option>
+                                <option value="3">OpTiOn 3</option>
+                                <option value="4">OpTiOn 4</option>
+                                <option value="5">OpTiOn 5</option>
+                                <option value="6">OpTiOn 6</option>
+                                <option value="7">OpTiOn 7</option>
+                                <option value="8">OpTiOn 8</option>
+                                <option value="9">OpTiOn 9</option>
+                                <option value="10">OpTiOn 10</option>
+                                <option value="11">OpTiOn 11</option>
+                                <option value="12">OpTiOn 12</option>
+                                <option value="13">OpTiOn 13</option>
+                                <option value="14">OpTiOn 14</option>
+                                <option value="15">OpTiOn 15</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2701,46 +2802,48 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code id="configuration-options-enableFullValueFiltering">enableFullValueFiltering</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        Set to <code>true</code> to enable full value filtering, that is all options are shown where the query is a prefix of. An example is given here: <a href="https://github.com/davidstutz/bootstrap-multiselect/pull/555">#555</a>.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code id="configuration-options-enableFullValueFiltering">enableFullValueFiltering</code>
+                    </td>
+                    <td>
+                        <p>
+                            Set to <code>true</code> to enable full value filtering, that is all options are shown where
+                            the query is a prefix of. An example is given here: <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/pull/555">#555</a>.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-enableFullValueFiltering').multiselect({
-                                                    enableFiltering: true,
-                                                    enableFullValueFiltering: true
-                                                });
-                                            });
-                                        </script>
-                                        <select id="example-enableFullValueFiltering" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                            <option value="7">Option 7</option>
-                                            <option value="8">Option 8</option>
-                                            <option value="9">Option 9</option>
-                                            <option value="10">Option 10</option>
-                                            <option value="11">Option 11</option>
-                                            <option value="12">Option 12</option>
-                                            <option value="13">Option 13</option>
-                                            <option value="14">Option 14</option>
-                                            <option value="15">Option 15</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-enableFullValueFiltering').multiselect({
+                                        enableFiltering: true,
+                                        enableFullValueFiltering: true
+                                    });
+                                });
+                            </script>
+                            <select id="example-enableFullValueFiltering" multiple="multiple">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                                <option value="4">Option 4</option>
+                                <option value="5">Option 5</option>
+                                <option value="6">Option 6</option>
+                                <option value="7">Option 7</option>
+                                <option value="8">Option 8</option>
+                                <option value="9">Option 9</option>
+                                <option value="10">Option 10</option>
+                                <option value="11">Option 11</option>
+                                <option value="12">Option 12</option>
+                                <option value="13">Option 13</option>
+                                <option value="14">Option 14</option>
+                                <option value="15">Option 15</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2751,50 +2854,52 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code id="configuration-options-filterBehavior">filterBehavior</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        The options are filtered based on their <code>text</code>. This behavior can be changed to use the <code>value</code> of the options or <code>both</code> the text and the value.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code id="configuration-options-filterBehavior">filterBehavior</code>
+                    </td>
+                    <td>
+                        <p>
+                            The options are filtered based on their <code>text</code>. This behavior can be changed to
+                            use the <code>value</code> of the options or <code>both</code> the text and the value.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-filterBehavior').multiselect({
-                                                    enableFiltering: true,
-                                                    filterBehavior: 'value'
-                                                });
-                                            });
-                                        </script>
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-filterBehavior').multiselect({
+                                        enableFiltering: true,
+                                        filterBehavior: 'value'
+                                    });
+                                });
+                            </script>
 
-                                        <p>
-                                            In this example, the options have values from <code>a</code> to <code>n</code>. Instead of searching the text of the options, the value of the options is searched.
-                                        </p>
+                            <p>
+                                In this example, the options have values from <code>a</code> to <code>n</code>. Instead
+                                of searching the text of the options, the value of the options is searched.
+                            </p>
 
-                                        <select id="example-filterBehavior" multiple="multiple">
-                                            <option value="a">Option 1</option>
-                                            <option value="b">Option 2</option>
-                                            <option value="c">Option 3</option>
-                                            <option value="d">Option 4</option>
-                                            <option value="e">Option 5</option>
-                                            <option value="f">Option 6</option>
-                                            <option value="g">Option 7</option>
-                                            <option value="h">Option 8</option>
-                                            <option value="i">Option 9</option>
-                                            <option value="j">Option 10</option>
-                                            <option value="k">Option 11</option>
-                                            <option value="l">Option 12</option>
-                                            <option value="m">Option 13</option>
-                                            <option value="n">Option 14</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                            <select id="example-filterBehavior" multiple="multiple">
+                                <option value="a">Option 1</option>
+                                <option value="b">Option 2</option>
+                                <option value="c">Option 3</option>
+                                <option value="d">Option 4</option>
+                                <option value="e">Option 5</option>
+                                <option value="f">Option 6</option>
+                                <option value="g">Option 7</option>
+                                <option value="h">Option 8</option>
+                                <option value="i">Option 9</option>
+                                <option value="j">Option 10</option>
+                                <option value="k">Option 11</option>
+                                <option value="l">Option 12</option>
+                                <option value="m">Option 13</option>
+                                <option value="n">Option 14</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2821,46 +2926,46 @@
     &lt;option value="n"&gt;Option 14&lt;/option&gt;
 &lt;/select&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code id="configuration-options-filterPlaceholder">filterPlaceholder</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        The placeholder used for the filter input.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code id="configuration-options-filterPlaceholder">filterPlaceholder</code>
+                    </td>
+                    <td>
+                        <p>
+                            The placeholder used for the filter input.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
-                                                $('#example-filter-placeholder').multiselect({
-                                                    enableFiltering: true,
-                                                    filterPlaceholder: 'Search for something...'
-                                                });
-                                            });
-                                        </script>
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-filter-placeholder').multiselect({
+                                        enableFiltering: true,
+                                        filterPlaceholder: 'Search for something...'
+                                    });
+                                });
+                            </script>
 
-                                        <select id="example-filter-placeholder" multiple="multiple">
-                                            <option value="a">Option 1</option>
-                                            <option value="b">Option 2</option>
-                                            <option value="c">Option 3</option>
-                                            <option value="d">Option 4</option>
-                                            <option value="e">Option 5</option>
-                                            <option value="f">Option 6</option>
-                                            <option value="g">Option 7</option>
-                                            <option value="h">Option 8</option>
-                                            <option value="i">Option 9</option>
-                                            <option value="j">Option 10</option>
-                                            <option value="k">Option 11</option>
-                                            <option value="l">Option 12</option>
-                                            <option value="m">Option 13</option>
-                                            <option value="n">Option 14</option>
-                                        </select>
-                                    </div>
-                                    <div class="highlight">
+                            <select id="example-filter-placeholder" multiple="multiple">
+                                <option value="a">Option 1</option>
+                                <option value="b">Option 2</option>
+                                <option value="c">Option 3</option>
+                                <option value="d">Option 4</option>
+                                <option value="e">Option 5</option>
+                                <option value="f">Option 6</option>
+                                <option value="g">Option 7</option>
+                                <option value="h">Option 8</option>
+                                <option value="i">Option 9</option>
+                                <option value="j">Option 10</option>
+                                <option value="k">Option 11</option>
+                                <option value="l">Option 12</option>
+                                <option value="m">Option 13</option>
+                                <option value="n">Option 14</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2887,28 +2992,79 @@
     &lt;option value="n"&gt;Option 14&lt;/option&gt;
 &lt;/select&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code id="configuration-options-enableReplaceDiacritics">enableReplaceDiacritics</code>
+                    </td>
+                    <td>
+                        <p>
+                            Replace diacritics (ă,ş,ţ etc) with their "normal" form
+                        </p>
 
-                    <div class="page-header">
-                        <h2 id="templates">Templates</h2>
-                    </div>
-                    
-                    
-                    <p>
-                        The generated HTML markup can be controlled using templates. Basically, templates are simple configuration options. The default templates are shown below:
-                    </p>
-                    
-                    <p class="alert alert-warning">
-                        However, note that messing with the template's classes may cause unexpected behavior. For example the button should always have the class <code>.multiselect</code>,
-                    </p>
-                    
-                    <p class="alert alert-info">
-                        In addition, note that other options may also have influence on the templates, for example the <code>buttonClass</code> option.
-                    </p>
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
+                                    $('#example-filter-enableReplaceDiacritics').multiselect({
+                                        enableFiltering: true,
+                                        enableCaseInsensitiveFiltering: true
+                                    });
+                                });
+                            </script>
+
+                            <select id="example-filter-enableReplaceDiacritics" multiple="multiple">
+                                <option value="a">Bière</option>
+                                <option value="b">birrë</option>
+                                <option value="c">Øl</option>
+                                <option value="d">pivə</option>
+                                <option value="e">Sör</option>
+                            </select>
+                        </div>
+                        <div class="highlight">
+<pre class="prettyprint linenums">
+&lt;script type=&quot;text/javascript&quot;&gt;
+    $(document).ready(function() {
+        $('#example-filter-enableReplaceDiacritics').multiselect({
+            enableReplaceDiacritics: true,
+            enableCaseInsensitiveFiltering : true
+        });
+    });
+&lt;/script&gt;
+&lt;select id="example-filter-enableReplaceDiacritics" multiple="multiple"&gt;
+    &lt;option value="a"&gt;Bière&lt;/option&gt;
+    &lt;option value="b"&gt;birrë&lt;/option&gt;
+    &lt;option value="c"&gt;Øl&lt;/option&gt;
+    &lt;option value="d"&gt;pivə&lt;/option&gt;
+    &lt;option value="e"&gt;Sör&lt;/option&gt;
+&lt;/select>
+</pre>
+                        </div>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+
+            <div class="page-header">
+                <h2 id="templates">Templates</h2>
+            </div>
+
+
+            <p>
+                The generated HTML markup can be controlled using templates. Basically, templates are simple
+                configuration options. The default templates are shown below:
+            </p>
+
+            <p class="alert alert-warning">
+                However, note that messing with the template's classes may cause unexpected behavior. For example the
+                button should always have the class <code>.multiselect</code>,
+            </p>
+
+            <p class="alert alert-info">
+                In addition, note that other options may also have influence on the templates, for example the <code>buttonClass</code>
+                option.
+            </p>
                     
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
@@ -2927,40 +3083,40 @@
     });
 &lt;/script&gt;
 </pre>
-                    
-                    <p>
-                        For example other elements instead of buttons may be used by adapting the template:
-                    </p>
-                    
-                    <div class="example">
-                        <script type="text/javascript">
-                            $(document).ready(function() {
-                                $('#example-templates-button').multiselect({
-                                    buttonContainer: '<div></div>',
-                                    buttonClass: '',
-                                    templates: {
-                                        button: '<span class="multiselect dropdown-toggle" data-toggle="dropdown">Click me!</span>'
-                                    }
-                                });
-                            });
-                        </script>
-                        <style type="text/css">
-                            span.multiselect {
-                                padding: 2px 6px;
-                                font-weight: bold;
-                                cursor: pointer;
+
+            <p>
+                For example other elements instead of buttons may be used by adapting the template:
+            </p>
+
+            <div class="example">
+                <script type="text/javascript">
+                    $(document).ready(function () {
+                        $('#example-templates-button').multiselect({
+                            buttonContainer: '<div></div>',
+                            buttonClass: '',
+                            templates: {
+                                button: '<span class="multiselect dropdown-toggle" data-toggle="dropdown">Click me!</span>'
                             }
-                        </style>
-                        <select id="example-templates-button" multiple="multiple">
-                            <option value="1">Option 1</option>
-                            <option value="2">Option 2</option>
-                            <option value="3">Option 3</option>
-                            <option value="4">Option 4</option>
-                            <option value="5">Option 5</option>
-                            <option value="6">Option 6</option>
-                        </select>
-                    </div>
-                    <div class="highlight">
+                        });
+                    });
+                </script>
+                <style type="text/css">
+                    span.multiselect {
+                        padding: 2px 6px;
+                        font-weight: bold;
+                        cursor: pointer;
+                    }
+                </style>
+                <select id="example-templates-button" multiple="multiple">
+                    <option value="1">Option 1</option>
+                    <option value="2">Option 2</option>
+                    <option value="3">Option 3</option>
+                    <option value="4">Option 4</option>
+                    <option value="5">Option 5</option>
+                    <option value="6">Option 6</option>
+                </select>
+            </div>
+            <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -2982,47 +3138,48 @@
     }
 &lt;/style&gt;
 </pre>
-                    </div>
-                    
-                    <div class="page-header">
-                        <h2 id="methods">Methods</h2>
-                    </div>
+            </div>
 
-                    <table class="table">
-                        <tbody>
-                            <tr>
-                                <td>
-                                    <code>.multiselect('destroy')</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        This method is used to destroy the plugin on the given element - meaning unbinding the plugin.
-                                    </p>
+            <div class="page-header">
+                <h2 id="methods">Methods</h2>
+            </div>
 
-                                    <div class="example">
-                                        <div class="btn-group">
-                                            <script type="text/javascript">
-                                                $(document).ready(function() {
-                                                    $('#example-destroy').multiselect();
-                                                    $('#example-destroy-button').on('click', function() {
-                                                        $('#example-destroy').multiselect('destroy');
-                                                    });
-                                                });
-                                            </script>
-                                            <div class="btn-group">
-                                                <select id="example-destroy" multiple="multiple">
-                                                    <option value="1">Option 1</option>
-                                                    <option value="2">Option 2</option>
-                                                    <option value="3">Option 3</option>
-                                                    <option value="4">Option 4</option>
-                                                    <option value="5">Option 5</option>
-                                                    <option value="6">Option 6</option>
-                                                </select>
-                                                <button id="example-destroy-button" class="btn btn-danger">Destroy/Unbind</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+            <table class="table">
+                <tbody>
+                <tr>
+                    <td>
+                        <code>.multiselect('destroy')</code>
+                    </td>
+                    <td>
+                        <p>
+                            This method is used to destroy the plugin on the given element - meaning unbinding the
+                            plugin.
+                        </p>
+
+                        <div class="example">
+                            <div class="btn-group">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-destroy').multiselect();
+                                        $('#example-destroy-button').on('click', function () {
+                                            $('#example-destroy').multiselect('destroy');
+                                        });
+                                    });
+                                </script>
+                                <div class="btn-group">
+                                    <select id="example-destroy" multiple="multiple">
+                                        <option value="1">Option 1</option>
+                                        <option value="2">Option 2</option>
+                                        <option value="3">Option 3</option>
+                                        <option value="4">Option 4</option>
+                                        <option value="5">Option 5</option>
+                                        <option value="6">Option 6</option>
+                                    </select>
+                                    <button id="example-destroy-button" class="btn btn-danger">Destroy/Unbind</button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -3033,59 +3190,64 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code>.multiselect('refresh')</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        This method is used to refresh the checked checkboxes based on the currently selected options within the <code>select</code>. Click &apos;Select some options&apos; to select some of the options. Then click refresh. The plugin will update the checkboxes accordingly.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code>.multiselect('refresh')</code>
+                    </td>
+                    <td>
+                        <p>
+                            This method is used to refresh the checked checkboxes based on the currently selected
+                            options within the <code>select</code>. Click &apos;Select some options&apos; to select some
+                            of the options. Then click refresh. The plugin will update the checkboxes accordingly.
+                        </p>
 
-                                    <div class="example">
-                                        <div class="btn-group">
-                                            <script type="text/javascript">
-                                                $(document).ready(function() {
-                                                    $('#example-refresh').multiselect();
+                        <div class="example">
+                            <div class="btn-group">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-refresh').multiselect();
 
-                                                    $('#example-refresh-select').on('click', function() {
-                                                        $('option[value="1"]', $('#example-refresh')).prop('selected', true);
-                                                        $('option[value="3"]', $('#example-refresh')).prop('selected', true);
-                                                        $('option[value="4"]', $('#example-refresh')).prop('selected', true);
+                                        $('#example-refresh-select').on('click', function () {
+                                            $('option[value="1"]', $('#example-refresh')).prop('selected', true);
+                                            $('option[value="3"]', $('#example-refresh')).prop('selected', true);
+                                            $('option[value="4"]', $('#example-refresh')).prop('selected', true);
 
-                                                        alert('Option 1, 2 and 4.');
-                                                    });
+                                            alert('Option 1, 2 and 4.');
+                                        });
 
-                                                    $('#example-refresh-deselect').on('click', function() {
-                                                        $('option', $('#example-refresh')).each(function(element) {
-                                                            $(this).removeAttr('selected').prop('selected', false);
-                                                        });
-                                                    });
+                                        $('#example-refresh-deselect').on('click', function () {
+                                            $('option', $('#example-refresh')).each(function (element) {
+                                                $(this).removeAttr('selected').prop('selected', false);
+                                            });
+                                        });
 
-                                                    $('#example-refresh-button').on('click', function() {
-                                                        $('#example-refresh').multiselect('refresh');
-                                                    });
-                                                });
-                                            </script>
-                                            <div class="btn-group">
-                                                <select id="example-refresh" multiple="multiple">
-                                                    <option value="1">Option 1</option>
-                                                    <option value="2">Option 2</option>
-                                                    <option value="3">Option 3</option>
-                                                    <option value="4">Option 4</option>
-                                                    <option value="5">Option 5</option>
-                                                    <option value="6">Option 6</option>
-                                                </select>
-                                                <button id="example-refresh-select" class="btn btn-default">Select some options!</button>
-                                                <button id="example-refresh-deselect" class="btn btn-default">Deselect some options...</button>
-                                                <button id="example-refresh-button" class="btn btn-primary">Refresh</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                                        $('#example-refresh-button').on('click', function () {
+                                            $('#example-refresh').multiselect('refresh');
+                                        });
+                                    });
+                                </script>
+                                <div class="btn-group">
+                                    <select id="example-refresh" multiple="multiple">
+                                        <option value="1">Option 1</option>
+                                        <option value="2">Option 2</option>
+                                        <option value="3">Option 3</option>
+                                        <option value="4">Option 4</option>
+                                        <option value="5">Option 5</option>
+                                        <option value="6">Option 6</option>
+                                    </select>
+                                    <button id="example-refresh-select" class="btn btn-default">Select some options!
+                                    </button>
+                                    <button id="example-refresh-deselect" class="btn btn-default">Deselect some
+                                        options...
+                                    </button>
+                                    <button id="example-refresh-button" class="btn btn-primary">Refresh</button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -3111,55 +3273,57 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code>.multiselect('rebuild')</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        Rebuilds the whole dropdown menu. All selected options will remain selected (if still existent!).
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code>.multiselect('rebuild')</code>
+                    </td>
+                    <td>
+                        <p>
+                            Rebuilds the whole dropdown menu. All selected options will remain selected (if still
+                            existent!).
+                        </p>
 
-                                    <div class="example">
-                                        <div class="btn-group">
-                                            <script type="text/javascript">
-                                                $(document).ready(function() {
-                                                    $('#example-rebuild').multiselect();
+                        <div class="example">
+                            <div class="btn-group">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-rebuild').multiselect();
 
-                                                    $('#example-rebuild-button').on('click', function() {
-                                                        $('#example-rebuild').multiselect('rebuild');
-                                                    });
+                                        $('#example-rebuild-button').on('click', function () {
+                                            $('#example-rebuild').multiselect('rebuild');
+                                        });
 
-                                                    $('#example-rebuild-add').on('click', function() {
-                                                        $('#example-rebuild').append('<option value="add1">Addition 1</option><option value="add2">Addition 2</option><option value="add3">Addition 3</option>');
-                                                    });
+                                        $('#example-rebuild-add').on('click', function () {
+                                            $('#example-rebuild').append('<option value="add1">Addition 1</option><option value="add2">Addition 2</option><option value="add3">Addition 3</option>');
+                                        });
 
-                                                    $('#example-rebuild-delete').on('click', function() {
-                                                        $('option[value="add1"]', $('#example-rebuild')).remove();
-                                                        $('option[value="add2"]', $('#example-rebuild')).remove();
-                                                        $('option[value="add3"]', $('#example-rebuild')).remove();
-                                                    });
-                                                });
-                                            </script>
-                                            <div class="btn-group">
-                                                <select id="example-rebuild" multiple="multiple">
-                                                    <option value="1">Option 1</option>
-                                                    <option value="2">Option 2</option>
-                                                    <option value="3">Option 3</option>
-                                                    <option value="4">Option 4</option>
-                                                    <option value="5">Option 5</option>
-                                                    <option value="6">Option 6</option>
-                                                </select>
-                                                <button id="example-rebuild-add" class="btn btn-default">Add some options!</button>
-                                                <button id="example-rebuild-delete" class="btn btn-default">Remove some options...</button>
-                                                <button id="example-rebuild-button" class="btn btn-primary">Rebuild</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                                        $('#example-rebuild-delete').on('click', function () {
+                                            $('option[value="add1"]', $('#example-rebuild')).remove();
+                                            $('option[value="add2"]', $('#example-rebuild')).remove();
+                                            $('option[value="add3"]', $('#example-rebuild')).remove();
+                                        });
+                                    });
+                                </script>
+                                <div class="btn-group">
+                                    <select id="example-rebuild" multiple="multiple">
+                                        <option value="1">Option 1</option>
+                                        <option value="2">Option 2</option>
+                                        <option value="3">Option 3</option>
+                                        <option value="4">Option 4</option>
+                                        <option value="5">Option 5</option>
+                                        <option value="6">Option 6</option>
+                                    </select>
+                                    <button id="example-rebuild-add" class="btn btn-default">Add some options!</button>
+                                    <button id="example-rebuild-delete" class="btn btn-default">Remove some options...
+                                    </button>
+                                    <button id="example-rebuild-button" class="btn btn-primary">Rebuild</button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -3182,45 +3346,46 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code>.multiselect('select', value)</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        Selects an option by its value. Works also using an array of values.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code>.multiselect('select', value)</code>
+                    </td>
+                    <td>
+                        <p>
+                            Selects an option by its value. Works also using an array of values.
+                        </p>
 
-                                    <div class="example">
-                                        <div class="btn-group">
-                                            <script type="text/javascript">
-                                                $(document).ready(function() {
-                                                    $('#example-select').multiselect();
+                        <div class="example">
+                            <div class="btn-group">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-select').multiselect();
 
-                                                    $('#example-select-button').on('click', function() {
-                                                        $('#example-select').multiselect('select', ['1', '2', '4']);
+                                        $('#example-select-button').on('click', function () {
+                                            $('#example-select').multiselect('select', ['1', '2', '4']);
 
-                                                        alert('Selected 1, 2 and 4.');
-                                                    });
-                                                });
-                                            </script>
-                                            <div class="btn-group">
-                                                <select id="example-select" multiple="multiple">
-                                                    <option value="1">Option 1</option>
-                                                    <option value="2">Option 2</option>
-                                                    <option value="3">Option 3</option>
-                                                    <option value="4">Option 4</option>
-                                                    <option value="5">Option 5</option>
-                                                    <option value="6">Option 6</option>
-                                                </select>
-                                                <button id="example-select-button" class="btn btn-default">Select some options...</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                                            alert('Selected 1, 2 and 4.');
+                                        });
+                                    });
+                                </script>
+                                <div class="btn-group">
+                                    <select id="example-select" multiple="multiple">
+                                        <option value="1">Option 1</option>
+                                        <option value="2">Option 2</option>
+                                        <option value="3">Option 3</option>
+                                        <option value="4">Option 4</option>
+                                        <option value="5">Option 5</option>
+                                        <option value="6">Option 6</option>
+                                    </select>
+                                    <button id="example-select-button" class="btn btn-default">Select some options...
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -3234,41 +3399,45 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        The method provides an additional parameter: <code>.multiselect('select', value, triggerOnChange)</code>. If the second parameter is set to true, the method will manually trigger the <code>onChange</code> option.
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <div class="btn-group">
-                                            <script type="text/javascript">
-                                                $(document).ready(function() {
-                                                    $('#example-select-onChange').multiselect({
-                                                        onChange: function(option, checked, select) {
-                                                            alert('onChange triggered ...');
-                                                        }
-                                                    });
+                        </div>
 
-                                                    $('#example-select-onChange-button').on('click', function() {
-                                                        $('#example-select-onChange').multiselect('select', '1', true);
-                                                    });
-                                                });
-                                            </script>
-                                            <div class="btn-group">
-                                                <select id="example-select-onChange" multiple="multiple">
-                                                    <option value="1">Option 1</option>
-                                                    <option value="2">Option 2</option>
-                                                    <option value="3">Option 3</option>
-                                                    <option value="4">Option 4</option>
-                                                    <option value="5">Option 5</option>
-                                                    <option value="6">Option 6</option>
-                                                </select>
-                                                <button id="example-select-onChange-button" class="btn btn-default">Select one option</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                        <p>
+                            The method provides an additional parameter: <code>.multiselect('select', value,
+                            triggerOnChange)</code>. If the second parameter is set to true, the method will manually
+                            trigger the <code>onChange</code> option.
+                        </p>
+
+                        <div class="example">
+                            <div class="btn-group">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-select-onChange').multiselect({
+                                            onChange: function (option, checked, select) {
+                                                alert('onChange triggered ...');
+                                            }
+                                        });
+
+                                        $('#example-select-onChange-button').on('click', function () {
+                                            $('#example-select-onChange').multiselect('select', '1', true);
+                                        });
+                                    });
+                                </script>
+                                <div class="btn-group">
+                                    <select id="example-select-onChange" multiple="multiple">
+                                        <option value="1">Option 1</option>
+                                        <option value="2">Option 2</option>
+                                        <option value="3">Option 3</option>
+                                        <option value="4">Option 4</option>
+                                        <option value="5">Option 5</option>
+                                        <option value="6">Option 6</option>
+                                    </select>
+                                    <button id="example-select-onChange-button" class="btn btn-default">Select one
+                                        option
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -3284,41 +3453,44 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        The above parameter does also work when selecting multipe values. Note that <code>onChange</code> is called for each selected option individually!
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <div class="btn-group">
-                                            <script type="text/javascript">
-                                                $(document).ready(function() {
-                                                    $('#example-select-onChange-array').multiselect({
-                                                        onChange: function(option, checked, select) {
-                                                            alert('onChange triggered ...');
-                                                        }
-                                                    });
+                        </div>
 
-                                                    $('#example-select-onChange-array-button').on('click', function() {
-                                                        $('#example-select-onChange-array').multiselect('select', ['1', '3'], true);
-                                                    });
-                                                });
-                                            </script>
-                                            <div class="btn-group">
-                                                <select id="example-select-onChange-array" multiple="multiple">
-                                                    <option value="1">Option 1</option>
-                                                    <option value="2">Option 2</option>
-                                                    <option value="3">Option 3</option>
-                                                    <option value="4">Option 4</option>
-                                                    <option value="5">Option 5</option>
-                                                    <option value="6">Option 6</option>
-                                                </select>
-                                                <button id="example-select-onChange-array-button" class="btn btn-default">Select two options</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                        <p>
+                            The above parameter does also work when selecting multipe values. Note that
+                            <code>onChange</code> is called for each selected option individually!
+                        </p>
+
+                        <div class="example">
+                            <div class="btn-group">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-select-onChange-array').multiselect({
+                                            onChange: function (option, checked, select) {
+                                                alert('onChange triggered ...');
+                                            }
+                                        });
+
+                                        $('#example-select-onChange-array-button').on('click', function () {
+                                            $('#example-select-onChange-array').multiselect('select', ['1', '3'], true);
+                                        });
+                                    });
+                                </script>
+                                <div class="btn-group">
+                                    <select id="example-select-onChange-array" multiple="multiple">
+                                        <option value="1">Option 1</option>
+                                        <option value="2">Option 2</option>
+                                        <option value="3">Option 3</option>
+                                        <option value="4">Option 4</option>
+                                        <option value="5">Option 5</option>
+                                        <option value="6">Option 6</option>
+                                    </select>
+                                    <button id="example-select-onChange-array-button" class="btn btn-default">Select two
+                                        options
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -3334,45 +3506,47 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code>.multiselect('deselect', value)</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        Deselect an option by its value. Works also using an array of values.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code>.multiselect('deselect', value)</code>
+                    </td>
+                    <td>
+                        <p>
+                            Deselect an option by its value. Works also using an array of values.
+                        </p>
 
-                                    <div class="example">
-                                        <div class="btn-group">
-                                            <script type="text/javascript">
-                                                $(document).ready(function() {
-                                                    $('#example-deselect').multiselect();
+                        <div class="example">
+                            <div class="btn-group">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-deselect').multiselect();
 
-                                                    $('#example-deselect-button').on('click', function() {
-                                                        $('#example-deselect').multiselect('deselect', ['1', '2', '4']);
+                                        $('#example-deselect-button').on('click', function () {
+                                            $('#example-deselect').multiselect('deselect', ['1', '2', '4']);
 
-                                                        alert('Deselected 1, 2 and 4.');
-                                                    });
-                                                });
-                                            </script>
-                                            <div class="btn-group">
-                                                <select id="example-deselect" multiple="multiple">
-                                                    <option value="1">Option 1</option>
-                                                    <option value="2">Option 2</option>
-                                                    <option value="3">Option 3</option>
-                                                    <option value="4">Option 4</option>
-                                                    <option value="5">Option 5</option>
-                                                    <option value="6">Option 6</option>
-                                                </select>
-                                                <button id="example-deselect-button" class="btn btn-default">Deselect some options...</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                                            alert('Deselected 1, 2 and 4.');
+                                        });
+                                    });
+                                </script>
+                                <div class="btn-group">
+                                    <select id="example-deselect" multiple="multiple">
+                                        <option value="1">Option 1</option>
+                                        <option value="2">Option 2</option>
+                                        <option value="3">Option 3</option>
+                                        <option value="4">Option 4</option>
+                                        <option value="5">Option 5</option>
+                                        <option value="6">Option 6</option>
+                                    </select>
+                                    <button id="example-deselect-button" class="btn btn-default">Deselect some
+                                        options...
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -3386,41 +3560,45 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        The method provides an additional parameter: <code>.multiselect('deselect', value, triggerOnChange)</code>. If the second parameter is set to true, the method will manually trigger the <code>onChange</code> option.
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <div class="btn-group">
-                                            <script type="text/javascript">
-                                                $(document).ready(function() {
-                                                    $('#example-deselect-onChange').multiselect({
-                                                        onChange: function(option, checked, select) {
-                                                            alert('onChange triggered ...');
-                                                        }
-                                                    });
+                        </div>
 
-                                                    $('#example-deselect-onChange-button').on('click', function() {
-                                                        $('#example-deselect-onChange').multiselect('deselect', '1', true);
-                                                    });
-                                                });
-                                            </script>
-                                            <div class="btn-group">
-                                                <select id="example-deselect-onChange" multiple="multiple">
-                                                    <option value="1">Option 1</option>
-                                                    <option value="2">Option 2</option>
-                                                    <option value="3">Option 3</option>
-                                                    <option value="4">Option 4</option>
-                                                    <option value="5">Option 5</option>
-                                                    <option value="6">Option 6</option>
-                                                </select>
-                                                <button id="example-deselect-onChange-button" class="btn btn-default">Deselect one option</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                        <p>
+                            The method provides an additional parameter: <code>.multiselect('deselect', value,
+                            triggerOnChange)</code>. If the second parameter is set to true, the method will manually
+                            trigger the <code>onChange</code> option.
+                        </p>
+
+                        <div class="example">
+                            <div class="btn-group">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-deselect-onChange').multiselect({
+                                            onChange: function (option, checked, select) {
+                                                alert('onChange triggered ...');
+                                            }
+                                        });
+
+                                        $('#example-deselect-onChange-button').on('click', function () {
+                                            $('#example-deselect-onChange').multiselect('deselect', '1', true);
+                                        });
+                                    });
+                                </script>
+                                <div class="btn-group">
+                                    <select id="example-deselect-onChange" multiple="multiple">
+                                        <option value="1">Option 1</option>
+                                        <option value="2">Option 2</option>
+                                        <option value="3">Option 3</option>
+                                        <option value="4">Option 4</option>
+                                        <option value="5">Option 5</option>
+                                        <option value="6">Option 6</option>
+                                    </select>
+                                    <button id="example-deselect-onChange-button" class="btn btn-default">Deselect one
+                                        option
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -3436,41 +3614,44 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        The above parameter does also work when deselecting multiple options. Note that <code>onChange</code> is called for each deselected option individually.
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <div class="btn-group">
-                                            <script type="text/javascript">
-                                                $(document).ready(function() {
-                                                    $('#example-deselect-onChange-array').multiselect({
-                                                        onChange: function(option, checked, select) {
-                                                            alert('onChange triggered ...');
-                                                        }
-                                                    });
+                        </div>
 
-                                                    $('#example-deselect-onChange-array-button').on('click', function() {
-                                                        $('#example-deselect-onChange-array').multiselect('deselect', ['1', '3'], true);
-                                                    });
-                                                });
-                                            </script>
-                                            <div class="btn-group">
-                                                <select id="example-deselect-onChange-array" multiple="multiple">
-                                                    <option value="1" selected>Option 1</option>
-                                                    <option value="2">Option 2</option>
-                                                    <option value="3" selected>Option 3</option>
-                                                    <option value="4">Option 4</option>
-                                                    <option value="5">Option 5</option>
-                                                    <option value="6">Option 6</option>
-                                                </select>
-                                                <button id="example-deselect-onChange-array-button" class="btn btn-default">Deselect two options</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                        <p>
+                            The above parameter does also work when deselecting multiple options. Note that <code>onChange</code>
+                            is called for each deselected option individually.
+                        </p>
+
+                        <div class="example">
+                            <div class="btn-group">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-deselect-onChange-array').multiselect({
+                                            onChange: function (option, checked, select) {
+                                                alert('onChange triggered ...');
+                                            }
+                                        });
+
+                                        $('#example-deselect-onChange-array-button').on('click', function () {
+                                            $('#example-deselect-onChange-array').multiselect('deselect', ['1', '3'], true);
+                                        });
+                                    });
+                                </script>
+                                <div class="btn-group">
+                                    <select id="example-deselect-onChange-array" multiple="multiple">
+                                        <option value="1" selected>Option 1</option>
+                                        <option value="2">Option 2</option>
+                                        <option value="3" selected>Option 3</option>
+                                        <option value="4">Option 4</option>
+                                        <option value="5">Option 5</option>
+                                        <option value="6">Option 6</option>
+                                    </select>
+                                    <button id="example-deselect-onChange-array-button" class="btn btn-default">Deselect
+                                        two options
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -3486,57 +3667,64 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code>.multiselect('selectAll', justVisible)</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        Selects all options. If <code>justVisible</code> is set to <code>true</code> or not provided, all visible options are selected (when using the filter), otherweise (<code>justVisible</code> set to <code>false</code>) all options are selected.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code>.multiselect('selectAll', justVisible)</code>
+                    </td>
+                    <td>
+                        <p>
+                            Selects all options. If <code>justVisible</code> is set to <code>true</code> or not
+                            provided, all visible options are selected (when using the filter), otherweise (<code>justVisible</code>
+                            set to <code>false</code>) all options are selected.
+                        </p>
 
-                                    <p class="alert alert-info">
-                                        Note that setting <code>justVisible</code> to <code>true</code>, or providing no parameter will select all visible options, that is the dropdown needs to be opened.
-                                    </p>
-                                    
-                                    <p class="alert alert-info">
-                                        Currently, it is required to call <code>.multiselect('updateButtonText')</code> manually after calling <code>.multiselect('selectAll', justVisible)</code>.
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <div class="btn-group">
-                                            <script type="text/javascript">
-                                                $(document).ready(function() {
-                                                    $('#example-selectAll').multiselect();
+                        <p class="alert alert-info">
+                            Note that setting <code>justVisible</code> to <code>true</code>, or providing no parameter
+                            will select all visible options, that is the dropdown needs to be opened.
+                        </p>
 
-                                                    $('#example-selectAll-visible').on('click', function() {
-                                                        $('#example-selectAll').multiselect('selectAll', true);
-                                                        $('#example-selectAll').multiselect('updateButtonText');
-                                                    });
-                                                    $('#example-selectAll-all').on('click', function() {
-                                                        $('#example-selectAll').multiselect('selectAll', false);
-                                                        $('#example-selectAll').multiselect('updateButtonText');
-                                                    });
-                                                });
-                                            </script>
-                                            <div class="btn-group">
-                                                <select id="example-selectAll" multiple="multiple">
-                                                    <option value="1">Option 1</option>
-                                                    <option value="2">Option 2</option>
-                                                    <option value="3">Option 3</option>
-                                                    <option value="4">Option 4</option>
-                                                    <option value="5">Option 5</option>
-                                                    <option value="6">Option 6</option>
-                                                </select>
-                                                <button id="example-selectAll-visible" class="btn btn-default">Select all visible options</button>
-                                                <button id="example-selectAll-all" class="btn btn-default">Select all options</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                        <p class="alert alert-info">
+                            Currently, it is required to call <code>.multiselect('updateButtonText')</code> manually
+                            after calling <code>.multiselect('selectAll', justVisible)</code>.
+                        </p>
+
+                        <div class="example">
+                            <div class="btn-group">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-selectAll').multiselect();
+
+                                        $('#example-selectAll-visible').on('click', function () {
+                                            $('#example-selectAll').multiselect('selectAll', true);
+                                            $('#example-selectAll').multiselect('updateButtonText');
+                                        });
+                                        $('#example-selectAll-all').on('click', function () {
+                                            $('#example-selectAll').multiselect('selectAll', false);
+                                            $('#example-selectAll').multiselect('updateButtonText');
+                                        });
+                                    });
+                                </script>
+                                <div class="btn-group">
+                                    <select id="example-selectAll" multiple="multiple">
+                                        <option value="1">Option 1</option>
+                                        <option value="2">Option 2</option>
+                                        <option value="3">Option 3</option>
+                                        <option value="4">Option 4</option>
+                                        <option value="5">Option 5</option>
+                                        <option value="6">Option 6</option>
+                                    </select>
+                                    <button id="example-selectAll-visible" class="btn btn-default">Select all visible
+                                        options
+                                    </button>
+                                    <button id="example-selectAll-all" class="btn btn-default">Select all options
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -3553,57 +3741,64 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code>.multiselect('deselectAll', justVisible)</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        Deselects all options. If <code>justVisible</code> is set to <code>true</code> or not provided, all visible options are deselected, otherweise (<code>justVisible</code> set to <code>false</code>) all options are deselected.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code>.multiselect('deselectAll', justVisible)</code>
+                    </td>
+                    <td>
+                        <p>
+                            Deselects all options. If <code>justVisible</code> is set to <code>true</code> or not
+                            provided, all visible options are deselected, otherweise (<code>justVisible</code> set to
+                            <code>false</code>) all options are deselected.
+                        </p>
 
-                                    <p class="alert alert-info">
-                                        Note that setting <code>justVisible</code> to <code>true</code>, or providing no parameter will select all visible options, that is the dropdown needs to be opened.
-                                    </p>
-                                    
-                                    <p class="alert alert-info">
-                                        Currently, it is required to call <code>.multiselect('updateButtonText')</code> manually after calling <code>.multiselect('selectAll', justVisible)</code>.
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <div class="btn-group">
-                                            <script type="text/javascript">
-                                                $(document).ready(function() {
-                                                    $('#example-deselectAll').multiselect();
+                        <p class="alert alert-info">
+                            Note that setting <code>justVisible</code> to <code>true</code>, or providing no parameter
+                            will select all visible options, that is the dropdown needs to be opened.
+                        </p>
 
-                                                    $('#example-deselectAll-visible').on('click', function() {
-                                                        $('#example-deselectAll').multiselect('deselectAll', true);
-                                                        $('#example-deselectAll').multiselect('updateButtonText');
-                                                    });
-                                                    $('#example-deselectAll-all').on('click', function() {
-                                                        $('#example-deselectAll').multiselect('deselectAll', false);
-                                                        $('#example-deselectAll').multiselect('updateButtonText');
-                                                    });
-                                                });
-                                            </script>
-                                            <div class="btn-group">
-                                                <select id="example-deselectAll" multiple="multiple">
-                                                    <option value="1">Option 1</option>
-                                                    <option value="2">Option 2</option>
-                                                    <option value="3">Option 3</option>
-                                                    <option value="4">Option 4</option>
-                                                    <option value="5">Option 5</option>
-                                                    <option value="6">Option 6</option>
-                                                </select>
-                                                <button id="example-deselectAll-visible" class="btn btn-default">Deselect all visible options</button>
-                                                <button id="example-deselectAll-all" class="btn btn-default">Deselect all options</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                        <p class="alert alert-info">
+                            Currently, it is required to call <code>.multiselect('updateButtonText')</code> manually
+                            after calling <code>.multiselect('selectAll', justVisible)</code>.
+                        </p>
+
+                        <div class="example">
+                            <div class="btn-group">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-deselectAll').multiselect();
+
+                                        $('#example-deselectAll-visible').on('click', function () {
+                                            $('#example-deselectAll').multiselect('deselectAll', true);
+                                            $('#example-deselectAll').multiselect('updateButtonText');
+                                        });
+                                        $('#example-deselectAll-all').on('click', function () {
+                                            $('#example-deselectAll').multiselect('deselectAll', false);
+                                            $('#example-deselectAll').multiselect('updateButtonText');
+                                        });
+                                    });
+                                </script>
+                                <div class="btn-group">
+                                    <select id="example-deselectAll" multiple="multiple">
+                                        <option value="1">Option 1</option>
+                                        <option value="2">Option 2</option>
+                                        <option value="3">Option 3</option>
+                                        <option value="4">Option 4</option>
+                                        <option value="5">Option 5</option>
+                                        <option value="6">Option 6</option>
+                                    </select>
+                                    <button id="example-deselectAll-visible" class="btn btn-default">Deselect all
+                                        visible options
+                                    </button>
+                                    <button id="example-deselectAll-all" class="btn btn-default">Deselect all options
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -3620,60 +3815,65 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code>.multiselect('updateButtonText')</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        When manually selecting/deselecting options and the corresponding checkboxes, this function updates the text and title of the button.
-                                    </p>
-                                    
-                                    <p class="alert alert-info">
-                                        Note that usually this method is only needed when using <code>.multiselect('selectAll', justVisible)</code> or <code>.multiselect('deselectAll', justVisible)</code>. In all other cases, <code>.multiselect('refresh')</code> should be used.
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <div class="btn-group">
-                                            <script type="text/javascript">
-                                                $(document).ready(function() {
-                                                    $('#example-updateButtonText').multiselect({
-                                                        buttonContainer: '<div class="btn-group" id="example-updateButtonText-container"></div>'
-                                                    });
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code>.multiselect('updateButtonText')</code>
+                    </td>
+                    <td>
+                        <p>
+                            When manually selecting/deselecting options and the corresponding checkboxes, this function
+                            updates the text and title of the button.
+                        </p>
 
-                                                    $('#example-updateButtonText-select').on('click', function() {
-                                                        $('option[value="1"]', $('#example-updateButtonText')).prop('selected', true);
-                                                        $('option[value="3"]', $('#example-updateButtonText')).prop('selected', true);
-                                                        
-                                                        $('input[value="1"]', $('#example-updateButtonText-container')).prop('checked', true);
-                                                        $('input[value="3"]', $('#example-updateButtonText-container')).prop('checked', true);
-                                                        
-                                                        $('input[value="1"]', $('#example-updateButtonText-container')).closest('li').addClass('active');
-                                                        $('input[value="3"]', $('#example-updateButtonText-container')).closest('li').addClass('active');
-                                                    });
-                                                    $('#example-updateButtonText-update').on('click', function() {
-                                                        $('#example-updateButtonText').multiselect('updateButtonText');
-                                                    });
-                                                });
-                                            </script>
-                                            <div class="btn-group">
-                                                <select id="example-updateButtonText" multiple="multiple">
-                                                    <option value="1">Option 1</option>
-                                                    <option value="2">Option 2</option>
-                                                    <option value="3">Option 3</option>
-                                                    <option value="4">Option 4</option>
-                                                    <option value="5">Option 5</option>
-                                                    <option value="6">Option 6</option>
-                                                </select>
-                                                <button id="example-updateButtonText-select" class="btn btn-default">Select some options ...</button>
-                                                <button id="example-updateButtonText-update" class="btn btn-default">Update</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                        <p class="alert alert-info">
+                            Note that usually this method is only needed when using <code>.multiselect('selectAll',
+                            justVisible)</code> or <code>.multiselect('deselectAll', justVisible)</code>. In all other
+                            cases, <code>.multiselect('refresh')</code> should be used.
+                        </p>
+
+                        <div class="example">
+                            <div class="btn-group">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-updateButtonText').multiselect({
+                                            buttonContainer: '<div class="btn-group" id="example-updateButtonText-container"></div>'
+                                        });
+
+                                        $('#example-updateButtonText-select').on('click', function () {
+                                            $('option[value="1"]', $('#example-updateButtonText')).prop('selected', true);
+                                            $('option[value="3"]', $('#example-updateButtonText')).prop('selected', true);
+
+                                            $('input[value="1"]', $('#example-updateButtonText-container')).prop('checked', true);
+                                            $('input[value="3"]', $('#example-updateButtonText-container')).prop('checked', true);
+
+                                            $('input[value="1"]', $('#example-updateButtonText-container')).closest('li').addClass('active');
+                                            $('input[value="3"]', $('#example-updateButtonText-container')).closest('li').addClass('active');
+                                        });
+                                        $('#example-updateButtonText-update').on('click', function () {
+                                            $('#example-updateButtonText').multiselect('updateButtonText');
+                                        });
+                                    });
+                                </script>
+                                <div class="btn-group">
+                                    <select id="example-updateButtonText" multiple="multiple">
+                                        <option value="1">Option 1</option>
+                                        <option value="2">Option 2</option>
+                                        <option value="3">Option 3</option>
+                                        <option value="4">Option 4</option>
+                                        <option value="5">Option 5</option>
+                                        <option value="6">Option 6</option>
+                                    </select>
+                                    <button id="example-updateButtonText-select" class="btn btn-default">Select some
+                                        options ...
+                                    </button>
+                                    <button id="example-updateButtonText-update" class="btn btn-default">Update</button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -3686,72 +3886,74 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code>.multiselect('setOptions', options)</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        Used to change configuration after initializing the multiselect. This may be useful in combination with <code>.multiselect('rebuild')</code>.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code>.multiselect('setOptions', options)</code>
+                    </td>
+                    <td>
+                        <p>
+                            Used to change configuration after initializing the multiselect. This may be useful in
+                            combination with <code>.multiselect('rebuild')</code>.
+                        </p>
 
-                                    <div class="example">
-                                        <script type="text/javascript">
-                                            $(document).ready(function() {
+                        <div class="example">
+                            <script type="text/javascript">
+                                $(document).ready(function () {
 
-                                                var firstConfigurationSet = {
-                                                    includeSelectAllOption: false,
-                                                    enableFiltering: false
-                                                };
-                                                var secondConfigurationSet = {
-                                                    includeSelectAllOption: false,
-                                                    enableFiltering: true
-                                                };
+                                    var firstConfigurationSet = {
+                                        includeSelectAllOption: false,
+                                        enableFiltering: false
+                                    };
+                                    var secondConfigurationSet = {
+                                        includeSelectAllOption: false,
+                                        enableFiltering: true
+                                    };
 
-                                                var set = 1;
-                                                $('#example-setOptions').multiselect(firstConfigurationSet);
+                                    var set = 1;
+                                    $('#example-setOptions').multiselect(firstConfigurationSet);
 
-                                                function rebuildMultiselect(options) {
-                                                    $('#example-setOptions').multiselect('setOptions', options);
-                                                    $('#example-setOptions').multiselect('rebuild');
-                                                }
+                                    function rebuildMultiselect(options) {
+                                        $('#example-setOptions').multiselect('setOptions', options);
+                                        $('#example-setOptions').multiselect('rebuild');
+                                    }
 
-                                                $('#example-setOptions-button').on('click', function(event) {
-                                                    switch (set) {
-                                                        case 2:
-                                                            rebuildMultiselect(firstConfigurationSet);
+                                    $('#example-setOptions-button').on('click', function (event) {
+                                        switch (set) {
+                                            case 2:
+                                                rebuildMultiselect(firstConfigurationSet);
 
-                                                            $(this).text('Configuration Set 2');
-                                                            set = 1;
-                                                            break;
-                                                        case 1:
-                                                        default:
-                                                            rebuildMultiselect(secondConfigurationSet);
+                                                $(this).text('Configuration Set 2');
+                                                set = 1;
+                                                break;
+                                            case 1:
+                                            default:
+                                                rebuildMultiselect(secondConfigurationSet);
 
-                                                            $(this).text('Configuration Set 1');
-                                                            set = 2;
-                                                            break;
+                                                $(this).text('Configuration Set 1');
+                                                set = 2;
+                                                break;
 
-                                                    }
-                                                });
-                                            });
-                                        </script>
-                                        <div class="btn-group">
-                                            <select id="example-setOptions" multiple="multiple">
-                                                <option value="1">Option 1</option>
-                                                <option value="2">Option 2</option>
-                                                <option value="3">Option 3</option>
-                                                <option value="4">Option 4</option>
-                                                <option value="5">Option 5</option>
-                                                <option value="6">Option 6</option>
-                                            </select>
-                                            <button id="example-setOptions-button" class="btn btn-primary">Configuration Set 2</button>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                                        }
+                                    });
+                                });
+                            </script>
+                            <div class="btn-group">
+                                <select id="example-setOptions" multiple="multiple">
+                                    <option value="1">Option 1</option>
+                                    <option value="2">Option 2</option>
+                                    <option value="3">Option 3</option>
+                                    <option value="4">Option 4</option>
+                                    <option value="5">Option 5</option>
+                                    <option value="6">Option 6</option>
+                                </select>
+                                <button id="example-setOptions-button" class="btn btn-primary">Configuration Set 2
+                                </button>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -3794,43 +3996,43 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code>.multiselect('disable')</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        Disable both the underlying select and the dropdown button.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code>.multiselect('disable')</code>
+                    </td>
+                    <td>
+                        <p>
+                            Disable both the underlying select and the dropdown button.
+                        </p>
 
-                                    <div class="example">
-                                        <div class="btn-group">
-                                            <script type="text/javascript">
-                                                $(document).ready(function() {
-                                                    $('#example-disable').multiselect();
+                        <div class="example">
+                            <div class="btn-group">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-disable').multiselect();
 
-                                                    $('#example-disable-button').on('click', function() {
-                                                        $('#example-disable').multiselect('disable');
-                                                    });
-                                                });
-                                            </script>
-                                            <div class="btn-group">
-                                                <select id="example-disable" multiple="multiple">
-                                                    <option value="1">Option 1</option>
-                                                    <option value="2">Option 2</option>
-                                                    <option value="3">Option 3</option>
-                                                    <option value="4">Option 4</option>
-                                                    <option value="5">Option 5</option>
-                                                    <option value="6">Option 6</option>
-                                                </select>
-                                                <button id="example-disable-button" class="btn btn-primary">Disable...</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                                        $('#example-disable-button').on('click', function () {
+                                            $('#example-disable').multiselect('disable');
+                                        });
+                                    });
+                                </script>
+                                <div class="btn-group">
+                                    <select id="example-disable" multiple="multiple">
+                                        <option value="1">Option 1</option>
+                                        <option value="2">Option 2</option>
+                                        <option value="3">Option 3</option>
+                                        <option value="4">Option 4</option>
+                                        <option value="5">Option 5</option>
+                                        <option value="6">Option 6</option>
+                                    </select>
+                                    <button id="example-disable-button" class="btn btn-primary">Disable...</button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -3842,43 +4044,43 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code>.multiselect('enable')</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        Enable both the underlying select and the dropdown button.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code>.multiselect('enable')</code>
+                    </td>
+                    <td>
+                        <p>
+                            Enable both the underlying select and the dropdown button.
+                        </p>
 
-                                    <div class="example">
-                                        <div class="btn-group">
-                                            <script type="text/javascript">
-                                                $(document).ready(function() {
-                                                    $('#example-enable').multiselect();
+                        <div class="example">
+                            <div class="btn-group">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-enable').multiselect();
 
-                                                    $('#example-enable-button').on('click', function() {
-                                                        $('#example-enable').multiselect('enable');
-                                                    });
-                                                });
-                                            </script>
-                                            <div class="btn-group">
-                                                <select id="example-enable" disabled="disabled" multiple="multiple">
-                                                    <option value="1">Option 1</option>
-                                                    <option value="2">Option 2</option>
-                                                    <option value="3">Option 3</option>
-                                                    <option value="4">Option 4</option>
-                                                    <option value="5">Option 5</option>
-                                                    <option value="6">Option 6</option>
-                                                </select>
-                                                <button id="example-enable-button" class="btn btn-default">Enable!</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                                        $('#example-enable-button').on('click', function () {
+                                            $('#example-enable').multiselect('enable');
+                                        });
+                                    });
+                                </script>
+                                <div class="btn-group">
+                                    <select id="example-enable" disabled="disabled" multiple="multiple">
+                                        <option value="1">Option 1</option>
+                                        <option value="2">Option 2</option>
+                                        <option value="3">Option 3</option>
+                                        <option value="4">Option 4</option>
+                                        <option value="5">Option 5</option>
+                                        <option value="6">Option 6</option>
+                                    </select>
+                                    <button id="example-enable-button" class="btn btn-default">Enable!</button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -3890,39 +4092,39 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code>.multiselect('dataprovider', data)</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        This method is used to provide options programmatically. See the example below.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code>.multiselect('dataprovider', data)</code>
+                    </td>
+                    <td>
+                        <p>
+                            This method is used to provide options programmatically. See the example below.
+                        </p>
 
-                                    <div class="example">
-                                        <div class="btn-group">
-                                            <script type="text/javascript">
-                                                $(document).ready(function() {
-                                                    $('#example-dataprovider').multiselect();
+                        <div class="example">
+                            <div class="btn-group">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-dataprovider').multiselect();
 
-                                                    var options = [
-                                                        {label: 'Option 1', title: 'Option 1', value: '1', selected: true},
-                                                        {label: 'Option 2', title: 'Option 2', value: '2'},
-                                                        {label: 'Option 3', title: 'Option 3', value: '3', selected: true},
-                                                        {label: 'Option 4', title: 'Option 4', value: '4'},
-                                                        {label: 'Option 5', title: 'Option 5', value: '5'},
-                                                        {label: 'Option 6', title: 'Option 6', value: '6', disabled: true}
-                                                    ];
-                                                    $('#example-dataprovider').multiselect('dataprovider', options);
-                                                });
-                                            </script>
-                                            <select id="example-dataprovider" multiple="multiple"></select>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                                        var options = [
+                                            {label: 'Option 1', title: 'Option 1', value: '1', selected: true},
+                                            {label: 'Option 2', title: 'Option 2', value: '2'},
+                                            {label: 'Option 3', title: 'Option 3', value: '3', selected: true},
+                                            {label: 'Option 4', title: 'Option 4', value: '4'},
+                                            {label: 'Option 5', title: 'Option 5', value: '5'},
+                                            {label: 'Option 6', title: 'Option 6', value: '6', disabled: true}
+                                        ];
+                                        $('#example-dataprovider').multiselect('dataprovider', options);
+                                    });
+                                </script>
+                                <select id="example-dataprovider" multiple="multiple"></select>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $('#example-dataprovider').multiselect();
@@ -3939,41 +4141,41 @@
 &lt;/script&gt;
 &lt;select id=&quot;example-dataprovider&quot; multiple=&quot;multiple&quot;&gt;&lt;/select&gt;
 </pre>
-                                    </div>
-                                    
-                                    <p>
-                                        The method is also able to handle <code>optgroup</code>'s:
-                                    </p>
-                                    
-                                    <div class="example">
-                                        <div class="btn-group">
-                                            <script type="text/javascript">
-                                                $(document).ready(function() {
-                                                    $('#example-dataprovider-optgroups').multiselect();
+                        </div>
 
-                                                    var optgroups = [
-                                                        {
-                                                            label: 'Group 1', children: [
-                                                                {label: 'Option 1.1', value: '1-1', selected: true},
-                                                                {label: 'Option 1.2', value: '1-2'},
-                                                                {label: 'Option 1.3', value: '1-3'}
-                                                            ]
-                                                        },
-                                                        {
-                                                            label: 'Group 2', children: [
-                                                                {label: 'Option 2.1', value: '1'},
-                                                                {label: 'Option 2.2', value: '2'},
-                                                                {label: 'Option 2.3', value: '3', disabled: true}
-                                                            ]
-                                                        }
-                                                    ];
-                                                    $('#example-dataprovider-optgroups').multiselect('dataprovider', optgroups);
-                                                });
-                                            </script>
-                                            <select id="example-dataprovider-optgroups" multiple="multiple"></select>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                        <p>
+                            The method is also able to handle <code>optgroup</code>'s:
+                        </p>
+
+                        <div class="example">
+                            <div class="btn-group">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-dataprovider-optgroups').multiselect();
+
+                                        var optgroups = [
+                                            {
+                                                label: 'Group 1', children: [
+                                                {label: 'Option 1.1', value: '1-1', selected: true},
+                                                {label: 'Option 1.2', value: '1-2'},
+                                                {label: 'Option 1.3', value: '1-3'}
+                                            ]
+                                            },
+                                            {
+                                                label: 'Group 2', children: [
+                                                {label: 'Option 2.1', value: '1'},
+                                                {label: 'Option 2.2', value: '2'},
+                                                {label: 'Option 2.3', value: '3', disabled: true}
+                                            ]
+                                            }
+                                        ];
+                                        $('#example-dataprovider-optgroups').multiselect('dataprovider', optgroups);
+                                    });
+                                </script>
+                                <select id="example-dataprovider-optgroups" multiple="multiple"></select>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $('#example-dataprovider-optgroups').multiselect();
@@ -3998,39 +4200,42 @@
 &lt;/script&gt;
 &lt;select id=&quot;example-dataprovider-optgroups&quot; multiple=&quot;multiple&quot;&gt;&lt;/select&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <code>.multiselect('setAllSelectedText', value)</code>
-                                </td>
-                                <td>
-                                    <p>
-                                        This method is used to programmatically provide a new text to display in the button when all options are selected, at runtime.
-                                    </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <code>.multiselect('setAllSelectedText', value)</code>
+                    </td>
+                    <td>
+                        <p>
+                            This method is used to programmatically provide a new text to display in the button when all
+                            options are selected, at runtime.
+                        </p>
 
-                                    <div class="example">
-                                        <div class="btn-group">
-                                            <script type="text/javascript">
-                                                $(document).ready(function() {
-                                                    $('#example-set-all-selected-text').multiselect({allSelectedText: "Initial All Selected"});
-                                                    
-                                                    $('#new-all-selected-text-btn').click(function(){
-                                                        $('#example-set-all-selected-text').multiselect('setAllSelectedText', $('#new-all-selected-text-box').val());                                                        
-                                                    });
-                                                });
-                                            </script>
-                                            
-                                            <select id="example-set-all-selected-text" multiple="multiple">
-                                                <option value="1" selected>Option 1</option>
-                                            </select>
-                                            
-                                            <input id="new-all-selected-text-box" type="text" class="form-control" placeholder="Enter new text"/>
-                                            <input id="new-all-selected-text-btn" type="button" class="btn btn-default" value="Change All Selected Text"/>
-                                        </div>
-                                    </div>
-                                    <div class="highlight">
+                        <div class="example">
+                            <div class="btn-group">
+                                <script type="text/javascript">
+                                    $(document).ready(function () {
+                                        $('#example-set-all-selected-text').multiselect({allSelectedText: "Initial All Selected"});
+
+                                        $('#new-all-selected-text-btn').click(function () {
+                                            $('#example-set-all-selected-text').multiselect('setAllSelectedText', $('#new-all-selected-text-box').val());
+                                        });
+                                    });
+                                </script>
+
+                                <select id="example-set-all-selected-text" multiple="multiple">
+                                    <option value="1" selected>Option 1</option>
+                                </select>
+
+                                <input id="new-all-selected-text-box" type="text" class="form-control"
+                                       placeholder="Enter new text"/>
+                                <input id="new-all-selected-text-btn" type="button" class="btn btn-default"
+                                       value="Change All Selected Text"/>
+                            </div>
+                        </div>
+                        <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $('#example-set-all-selected-text').multiselect({allSelectedText: "Initial All Selected"});
@@ -4040,50 +4245,51 @@
     });
 &lt;/script&gt;
 </pre>
-                                    </div>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+                        </div>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
 
-                    <div class="page-header">
-                        <h2 id="further-examples">Further Examples</h2>
-                    </div>
+            <div class="page-header">
+                <h2 id="further-examples">Further Examples</h2>
+            </div>
 
-                    <p>
-                        Using the <code>onChange</code> configuration option, the following example asks for confirmation if deselecting an option.
-                    </p>
+            <p>
+                Using the <code>onChange</code> configuration option, the following example asks for confirmation if
+                deselecting an option.
+            </p>
 
-                    <div class="example">
-                        <script type="text/javascript">
-                            $(document).ready(function() {
-                                $('#example-confirmation').multiselect({
-                                    onChange: function(element, checked) {
-                                        if (checked === true) {
-                                            //action taken here if true
-                                        }
-                                        else if (checked === false) {
-                                            if (confirm('Do you wish to deselect the element?')) {
-                                                //action taken here
-                                            }
-                                            else {
-                                                $("#example-confirmation").multiselect('select', element.val());
-                                            }
-                                        }
+            <div class="example">
+                <script type="text/javascript">
+                    $(document).ready(function () {
+                        $('#example-confirmation').multiselect({
+                            onChange: function (element, checked) {
+                                if (checked === true) {
+                                    //action taken here if true
+                                }
+                                else if (checked === false) {
+                                    if (confirm('Do you wish to deselect the element?')) {
+                                        //action taken here
                                     }
-                                });
-                            });
-                        </script>
-                        <select id="example-confirmation" multiple="multiple">
-                            <option value="1">Option 1</option>
-                            <option value="2">Option 2</option>
-                            <option value="3">Option 3</option>
-                            <option value="4">Option 4</option>
-                            <option value="5">Option 5</option>
-                            <option value="6">Option 6</option>
-                        </select>
-                    </div>
-                    <div class="highlight">
+                                    else {
+                                        $("#example-confirmation").multiselect('select', element.val());
+                                    }
+                                }
+                            }
+                        });
+                    });
+                </script>
+                <select id="example-confirmation" multiple="multiple">
+                    <option value="1">Option 1</option>
+                    <option value="2">Option 2</option>
+                    <option value="3">Option 3</option>
+                    <option value="4">Option 4</option>
+                    <option value="5">Option 5</option>
+                    <option value="6">Option 6</option>
+                </select>
+            </div>
+            <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -4105,39 +4311,39 @@
     });
 &lt;/script&gt;
 </pre>
-                    </div>
+            </div>
 
-                    <p>
-                        The above approach can also be adapted to be used in 
-                    </p>
+            <p>
+                The above approach can also be adapted to be used in
+            </p>
 
-                    <div class="example">
-                        <script type="text/javascript">
-                            $(document).ready(function() {
-                                var lastSelected = $('#example-confirmation-single option:selected').val();
-                                $('#example-confirmation-single').multiselect({
-                                    onChange: function(element, checked) {
-                                        if (confirm('Do you wish to change the selection?')) {
-                                            lastSelected = element.val();
-                                        }
-                                        else {
-                                            $("#example-confirmation-single").multiselect('select', lastSelected);
-                                            $("#example-confirmation-single").multiselect('deselect', element.val());
-                                        }
-                                    }
-                                });
-                            });
-                        </script>
-                        <select id="example-confirmation-single">
-                            <option value="1">Option 1</option>
-                            <option value="2">Option 2</option>
-                            <option value="3">Option 3</option>
-                            <option value="4">Option 4</option>
-                            <option value="5">Option 5</option>
-                            <option value="6">Option 6</option>
-                        </select>
-                    </div>
-                    <div class="highlight">
+            <div class="example">
+                <script type="text/javascript">
+                    $(document).ready(function () {
+                        var lastSelected = $('#example-confirmation-single option:selected').val();
+                        $('#example-confirmation-single').multiselect({
+                            onChange: function (element, checked) {
+                                if (confirm('Do you wish to change the selection?')) {
+                                    lastSelected = element.val();
+                                }
+                                else {
+                                    $("#example-confirmation-single").multiselect('select', lastSelected);
+                                    $("#example-confirmation-single").multiselect('deselect', element.val());
+                                }
+                            }
+                        });
+                    });
+                </script>
+                <select id="example-confirmation-single">
+                    <option value="1">Option 1</option>
+                    <option value="2">Option 2</option>
+                    <option value="3">Option 3</option>
+                    <option value="4">Option 4</option>
+                    <option value="5">Option 5</option>
+                    <option value="6">Option 6</option>
+                </select>
+            </div>
+            <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -4156,56 +4362,57 @@
     });
 &lt;/script&gt;
 </pre>
-                    </div>
-                    
-                    <p>
-                        Limit the number of selected options using the <code>onChange</code> option. The user may only select a maximum of 4 options. Then all other options are disabled.
-                    </p>
+            </div>
 
-                    <div class="example">
-                        <script type="text/javascript">
-                            $(document).ready(function() {
-                                $('#example-limit').multiselect({
-                                    onChange: function(option, checked) {
-                                        // Get selected options.
-                                        var selectedOptions = $('#example-limit option:selected');
+            <p>
+                Limit the number of selected options using the <code>onChange</code> option. The user may only select a
+                maximum of 4 options. Then all other options are disabled.
+            </p>
 
-                                        if (selectedOptions.length >= 4) {
-                                            // Disable all other checkboxes.
-                                            var nonSelectedOptions = $('#example-limit option').filter(function() {
-                                                return !$(this).is(':selected');
-                                            });
+            <div class="example">
+                <script type="text/javascript">
+                    $(document).ready(function () {
+                        $('#example-limit').multiselect({
+                            onChange: function (option, checked) {
+                                // Get selected options.
+                                var selectedOptions = $('#example-limit option:selected');
 
-                                            var dropdown = $('#example-limit').siblings('.multiselect-container');
-                                            nonSelectedOptions.each(function() {
-                                                var input = $('input[value="' + $(this).val() + '"]');
-                                                input.prop('disabled', true);
-                                                input.parent('li').addClass('disabled');
-                                            });
-                                        }
-                                        else {
-                                            // Enable all checkboxes.
-                                            var dropdown = $('#example-limit').siblings('.multiselect-container');
-                                            $('#example-limit option').each(function() {
-                                                var input = $('input[value="' + $(this).val() + '"]');
-                                                input.prop('disabled', false);
-                                                input.parent('li').addClass('disabled');
-                                            });
-                                        }
-                                    }
-                                });
-                            });
-                        </script>
-                        <select id="example-limit" multiple="multiple">
-                            <option value="1">Option 1</option>
-                            <option value="2">Option 2</option>
-                            <option value="3">Option 3</option>
-                            <option value="4">Option 4</option>
-                            <option value="5">Option 5</option>
-                            <option value="6">Option 6</option>
-                        </select>
-                    </div>
-                    <div class="highlight">
+                                if (selectedOptions.length >= 4) {
+                                    // Disable all other checkboxes.
+                                    var nonSelectedOptions = $('#example-limit option').filter(function () {
+                                        return !$(this).is(':selected');
+                                    });
+
+                                    var dropdown = $('#example-limit').siblings('.multiselect-container');
+                                    nonSelectedOptions.each(function () {
+                                        var input = $('input[value="' + $(this).val() + '"]');
+                                        input.prop('disabled', true);
+                                        input.parent('li').addClass('disabled');
+                                    });
+                                }
+                                else {
+                                    // Enable all checkboxes.
+                                    var dropdown = $('#example-limit').siblings('.multiselect-container');
+                                    $('#example-limit option').each(function () {
+                                        var input = $('input[value="' + $(this).val() + '"]');
+                                        input.prop('disabled', false);
+                                        input.parent('li').addClass('disabled');
+                                    });
+                                }
+                            }
+                        });
+                    });
+                </script>
+                <select id="example-limit" multiple="multiple">
+                    <option value="1">Option 1</option>
+                    <option value="2">Option 2</option>
+                    <option value="3">Option 3</option>
+                    <option value="4">Option 4</option>
+                    <option value="5">Option 5</option>
+                    <option value="6">Option 6</option>
+                </select>
+            </div>
+            <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -4241,60 +4448,41 @@
     });
 &lt;/script&gt;
 </pre>
-                    </div>
+            </div>
 
-                    <p>
-                        Record the order the options are selected. When selecting an item an ordering number will be incremented and saved within the option.
-                    </p>
+            <p>
+                Record the order the options are selected. When selecting an item an ordering number will be incremented
+                and saved within the option.
+            </p>
 
-                    <div class="example">
-                        <script type="text/javascript">
-                            $(document).ready(function() {
-                                var orderCount = 0;
-                                $('#example-order').multiselect({
-                                    onChange: function(option, checked) {
-                                        if (checked) {
-                                            orderCount++;
-                                            $(option).data('order', orderCount);
-                                        }
-                                        else {
-                                            $(option).data('order', '');
-                                        }
-                                    },
-                                    buttonText: function(options) {
-                                        if (options.length === 0) {
-                                            return 'None selected';
-                                        }
-                                        else if (options.length > 3) {
-                                            return options.length + ' selected';
-                                        }
-                                        else {
-                                            var selected = [];
-                                            options.each(function() {
-                                                selected.push([$(this).text(), $(this).data('order')]);
-                                            });
-
-                                            selected.sort(function(a, b) {
-                                                return a[1] - b[1];
-                                            });
-
-                                            var text = '';
-                                            for (var i = 0; i < selected.length; i++) {
-                                                text += selected[i][0] + ', ';
-                                            }
-
-                                            return text.substr(0, text.length -2);
-                                        }
-                                    }
-                                });
-
-                                $('#example-order-button').on('click', function() {
+            <div class="example">
+                <script type="text/javascript">
+                    $(document).ready(function () {
+                        var orderCount = 0;
+                        $('#example-order').multiselect({
+                            onChange: function (option, checked) {
+                                if (checked) {
+                                    orderCount++;
+                                    $(option).data('order', orderCount);
+                                }
+                                else {
+                                    $(option).data('order', '');
+                                }
+                            },
+                            buttonText: function (options) {
+                                if (options.length === 0) {
+                                    return 'None selected';
+                                }
+                                else if (options.length > 3) {
+                                    return options.length + ' selected';
+                                }
+                                else {
                                     var selected = [];
-                                    $('#example-order option:selected').each(function() {
-                                        selected.push([$(this).val(), $(this).data('order')]);
+                                    options.each(function () {
+                                        selected.push([$(this).text(), $(this).data('order')]);
                                     });
 
-                                    selected.sort(function(a, b) {
+                                    selected.sort(function (a, b) {
                                         return a[1] - b[1];
                                     });
 
@@ -4302,25 +4490,45 @@
                                     for (var i = 0; i < selected.length; i++) {
                                         text += selected[i][0] + ', ';
                                     }
-                                    text = text.substring(0, text.length - 2);
 
-                                    alert(text);
-                                });
+                                    return text.substr(0, text.length - 2);
+                                }
+                            }
+                        });
+
+                        $('#example-order-button').on('click', function () {
+                            var selected = [];
+                            $('#example-order option:selected').each(function () {
+                                selected.push([$(this).val(), $(this).data('order')]);
                             });
-                        </script>
-                        <div class="btn-group">
-                            <select id="example-order" multiple="multiple">
-                                <option value="1">Option 1</option>
-                                <option value="2">Option 2</option>
-                                <option value="3">Option 3</option>
-                                <option value="4">Option 4</option>
-                                <option value="5">Option 5</option>
-                                <option value="6">Option 6</option>
-                            </select>
-                            <button id="example-order-button" class="btn btn-primary">Order</button>
-                        </div>
-                    </div>
-                    <div class="highlight">
+
+                            selected.sort(function (a, b) {
+                                return a[1] - b[1];
+                            });
+
+                            var text = '';
+                            for (var i = 0; i < selected.length; i++) {
+                                text += selected[i][0] + ', ';
+                            }
+                            text = text.substring(0, text.length - 2);
+
+                            alert(text);
+                        });
+                    });
+                </script>
+                <div class="btn-group">
+                    <select id="example-order" multiple="multiple">
+                        <option value="1">Option 1</option>
+                        <option value="2">Option 2</option>
+                        <option value="3">Option 3</option>
+                        <option value="4">Option 4</option>
+                        <option value="5">Option 5</option>
+                        <option value="6">Option 6</option>
+                    </select>
+                    <button id="example-order-button" class="btn btn-primary">Order</button>
+                </div>
+            </div>
+            <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -4383,39 +4591,40 @@
     });
 &lt;/script&gt;
 </pre>
-                    </div>
+            </div>
 
-                    <p>
-                        Simulate single selections using checkboxes. The behavior will be similar to a multiselect with radio buttons except that the selected option can be deselected again.
-                    </p>
+            <p>
+                Simulate single selections using checkboxes. The behavior will be similar to a multiselect with radio
+                buttons except that the selected option can be deselected again.
+            </p>
 
-                    <div class="example">
-                        <script type="text/javascript">
-                            $(document).ready(function() {
-                                $('#example-simulate-single').multiselect({
-                                    onChange: function(option, checked) {
-                                        var values = [];
-                                        $('#example-simulate-single option').each(function() {
-                                            if ($(this).val() !== option.val()) {
-                                                values.push($(this).val());
-                                            }
-                                        });
-
-                                        $('#example-simulate-single').multiselect('deselect', values);
+            <div class="example">
+                <script type="text/javascript">
+                    $(document).ready(function () {
+                        $('#example-simulate-single').multiselect({
+                            onChange: function (option, checked) {
+                                var values = [];
+                                $('#example-simulate-single option').each(function () {
+                                    if ($(this).val() !== option.val()) {
+                                        values.push($(this).val());
                                     }
                                 });
-                            });
-                        </script>
-                        <select id="example-simulate-single" multiple="multiple">
-                            <option value="1">Option 1</option>
-                            <option value="2">Option 2</option>
-                            <option value="3">Option 3</option>
-                            <option value="4">Option 4</option>
-                            <option value="5">Option 5</option>
-                            <option value="6">Option 6</option>
-                        </select>
-                    </div>
-                    <div class="highlight">
+
+                                $('#example-simulate-single').multiselect('deselect', values);
+                            }
+                        });
+                    });
+                </script>
+                <select id="example-simulate-single" multiple="multiple">
+                    <option value="1">Option 1</option>
+                    <option value="2">Option 2</option>
+                    <option value="3">Option 3</option>
+                    <option value="4">Option 4</option>
+                    <option value="5">Option 5</option>
+                    <option value="6">Option 6</option>
+                </select>
+            </div>
+            <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -4436,40 +4645,40 @@
     });
 &lt;/script&gt;
 </pre>
-                    </div>
+            </div>
 
-                    <p>
-                        Using a reset button together with a multiselect.
-                    </p>
-                    
-                    <div class="example">
-                        <script type="text/javascript">
-                            $(document).ready(function() {
-                                $('#example-reset').multiselect();
-                                $('#example-reset-form').on('reset', function() {
-                                    $('#example-reset option:selected').each(function() {
-                                        $(this).prop('selected', false);
-                                    })
+            <p>
+                Using a reset button together with a multiselect.
+            </p>
 
-                                    $('#example-reset').multiselect('refresh');
-                                });
-                            });
-                        </script>
-                        <form class="btn-group" id="example-reset-form">
-                            <div class="btn-group">
-                                <select id="example-reset" multiple="multiple">
-                                    <option value="1">Option 1</option>
-                                    <option value="2">Option 2</option>
-                                    <option value="3">Option 3</option>
-                                    <option value="4">Option 4</option>
-                                    <option value="5">Option 5</option>
-                                    <option value="6">Option 6</option>
-                                </select>
-                                <button type="reset" id="example-reset-button" class="btn btn-default">Reset</button>
-                            </div>
-                        </form>
+            <div class="example">
+                <script type="text/javascript">
+                    $(document).ready(function () {
+                        $('#example-reset').multiselect();
+                        $('#example-reset-form').on('reset', function () {
+                            $('#example-reset option:selected').each(function () {
+                                $(this).prop('selected', false);
+                            })
+
+                            $('#example-reset').multiselect('refresh');
+                        });
+                    });
+                </script>
+                <form class="btn-group" id="example-reset-form">
+                    <div class="btn-group">
+                        <select id="example-reset" multiple="multiple">
+                            <option value="1">Option 1</option>
+                            <option value="2">Option 2</option>
+                            <option value="3">Option 3</option>
+                            <option value="4">Option 4</option>
+                            <option value="5">Option 5</option>
+                            <option value="6">Option 6</option>
+                        </select>
+                        <button type="reset" id="example-reset-button" class="btn btn-default">Reset</button>
                     </div>
-                    <div class="highlight">
+                </form>
+            </div>
+            <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -4497,41 +4706,43 @@
     &lt;/div&gt;
 &lt;/form&gt;
 </pre>
-                    </div>
-                    
-                    <p>
-                        Multiselect can also be used in modals:
-                    </p>
-                    
-                    <div class="example">
-                        <script type="text/javascript">
-                            $(document).ready(function() {
-                                $('#example-modal').multiselect();
-                            });
-                        </script>
-                        <button class="btn btn-default" data-toggle="modal" data-target="#example-modal-modal">Launch modal</button>
-                        <div class="modal fade" id="example-modal-modal">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                                        <h4 class="modal-title">Bootstrap Multiselect</h4>
-                                    </div>
-                                    <div class="modal-body">
-                                        <select id="example-modal" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                </div>
+            </div>
+
+            <p>
+                Multiselect can also be used in modals:
+            </p>
+
+            <div class="example">
+                <script type="text/javascript">
+                    $(document).ready(function () {
+                        $('#example-modal').multiselect();
+                    });
+                </script>
+                <button class="btn btn-default" data-toggle="modal" data-target="#example-modal-modal">Launch modal
+                </button>
+                <div class="modal fade" id="example-modal-modal">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal"><span
+                                        aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                                <h4 class="modal-title">Bootstrap Multiselect</h4>
+                            </div>
+                            <div class="modal-body">
+                                <select id="example-modal" multiple="multiple">
+                                    <option value="1">Option 1</option>
+                                    <option value="2">Option 2</option>
+                                    <option value="3">Option 3</option>
+                                    <option value="4">Option 4</option>
+                                    <option value="5">Option 5</option>
+                                    <option value="6">Option 6</option>
+                                </select>
                             </div>
                         </div>
                     </div>
-                    <div class="highlight">
+                </div>
+            </div>
+            <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -4560,47 +4771,49 @@
     &lt;/div&gt;
 &lt;/div&gt;
 </pre>
-                    </div>
-                    
-                    <p>
-                        An example of using multiselect in an accordion/collapse:
-                    </p>
-                    
-                    <p class="alert alert-info">
-                        Note that the overflow of the <code>.panel</code> needs to be visible: <code>style="overflow:visible;"</code>. See the example below.
-                    </p>
-                    
-                    <div class="example">
-                        <script type="text/javascript">
-                            $(document).ready(function() {
-                                $('#example-collapse').multiselect();
-                            });
-                        </script>
-                        <div class="panel-group" id="example-collapse-accordion">
-                            <div class="panel panel-default" style="overflow:visible;">
-                                <div class="panel-heading">
-                                    <h4 class="panel-title">
-                                        <a data-toggle="collapse" data-parent="#example-collapse-accordion" href="#example-collapse-accordion-one">
-                                            Bootstrap Multiselect
-                                        </a>
-                                    </h4>
-                                </div>
-                                <div id="example-collapse-accordion-one" class="panel-collapse collapse in">
-                                    <div class="panel-body">
-                                        <select id="example-collapse" multiple="multiple">
-                                            <option value="1">Option 1</option>
-                                            <option value="2">Option 2</option>
-                                            <option value="3">Option 3</option>
-                                            <option value="4">Option 4</option>
-                                            <option value="5">Option 5</option>
-                                            <option value="6">Option 6</option>
-                                        </select>
-                                    </div>
-                                </div>
+            </div>
+
+            <p>
+                An example of using multiselect in an accordion/collapse:
+            </p>
+
+            <p class="alert alert-info">
+                Note that the overflow of the <code>.panel</code> needs to be visible:
+                <code>style="overflow:visible;"</code>. See the example below.
+            </p>
+
+            <div class="example">
+                <script type="text/javascript">
+                    $(document).ready(function () {
+                        $('#example-collapse').multiselect();
+                    });
+                </script>
+                <div class="panel-group" id="example-collapse-accordion">
+                    <div class="panel panel-default" style="overflow:visible;">
+                        <div class="panel-heading">
+                            <h4 class="panel-title">
+                                <a data-toggle="collapse" data-parent="#example-collapse-accordion"
+                                   href="#example-collapse-accordion-one">
+                                    Bootstrap Multiselect
+                                </a>
+                            </h4>
+                        </div>
+                        <div id="example-collapse-accordion-one" class="panel-collapse collapse in">
+                            <div class="panel-body">
+                                <select id="example-collapse" multiple="multiple">
+                                    <option value="1">Option 1</option>
+                                    <option value="2">Option 2</option>
+                                    <option value="3">Option 3</option>
+                                    <option value="4">Option 4</option>
+                                    <option value="5">Option 5</option>
+                                    <option value="6">Option 6</option>
+                                </select>
                             </div>
                         </div>
                     </div>
-                    <div class="highlight">
+                </div>
+            </div>
+            <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -4631,122 +4844,126 @@
     &lt;/div&gt;
 &lt;/div&gt;
 </pre>
-                    </div>
-                    
-                    <p>
-                        The examples below are aimed to demonstrate the performance of several features when using a large number of options:
-                    </p>
-                    <ul>
-                        <li>Using the select all option, <code>includeSelectAllOption</code> set to <code>true</code>.</li>
-                        <li>Additionally using a filter, <code>enableFiltering</code> set to <code>true</code>.</li>
-                        <li>Additionally using <code>enableClickableOptGroups</code>.</li>
-                        <li>Resetting the multiselect.</li>
-                    </ul>
-                    
-                    <p class="alert alert-warning">
-                        The below examples need to be activated. <b>Note that this may take some time!</b><br>
-                    </p>
-                    
-                    <p class="alert alert-info">
-                        Use <input type="text" id="example-large-options" value="1000" style="width: 50px;margin: 0px 4px;"/> options: <button id="example-large-enable" class="btn btn-primary">Enable Examples</button>
-                    </p>
-                    
-                    <div id="example-large-error">
-                        
-                    </div>
-                    
-                    <div class="example">
-                        <script type="text/javascript">
-                            $(document).ready(function() {
-                                $('#example-large-enable').on('click', function() {
-                                    var options = $('#example-large-options').val();
-                                    
-                                    if (options < 1 || options > 5000) {
-                                        $('#example-large-error').html('<p class="alert alert-error">Choose between 1 and 5000 options!</p>');
+            </div>
+
+            <p>
+                The examples below are aimed to demonstrate the performance of several features when using a large
+                number of options:
+            </p>
+            <ul>
+                <li>Using the select all option, <code>includeSelectAllOption</code> set to <code>true</code>.</li>
+                <li>Additionally using a filter, <code>enableFiltering</code> set to <code>true</code>.</li>
+                <li>Additionally using <code>enableClickableOptGroups</code>.</li>
+                <li>Resetting the multiselect.</li>
+            </ul>
+
+            <p class="alert alert-warning">
+                The below examples need to be activated. <b>Note that this may take some time!</b><br>
+            </p>
+
+            <p class="alert alert-info">
+                Use <input type="text" id="example-large-options" value="1000" style="width: 50px;margin: 0px 4px;"/>
+                options:
+                <button id="example-large-enable" class="btn btn-primary">Enable Examples</button>
+            </p>
+
+            <div id="example-large-error">
+
+            </div>
+
+            <div class="example">
+                <script type="text/javascript">
+                    $(document).ready(function () {
+                        $('#example-large-enable').on('click', function () {
+                            var options = $('#example-large-options').val();
+
+                            if (options < 1 || options > 5000) {
+                                $('#example-large-error').html('<p class="alert alert-error">Choose between 1 and 5000 options!</p>');
+                            }
+                            else {
+                                $('#example-large-includeSelectAllOption').html('');
+                                $('#example-large-includeSelectAllOption-enableFiltering').html('');
+                                $('#example-large-includeSelectAllOption-enableFiltering-enableClickableOptGroups').html('');
+                                $('#example-large-reset').html('');
+
+                                for (var j = 0; j < options; j++) {
+                                    i = j + 1;
+                                    $('#example-large-includeSelectAllOption').append('<option value="' + i.toString() + '">Option ' + i.toString() + '</option>');
+                                    $('#example-large-includeSelectAllOption-enableFiltering').append('<option value="' + i.toString() + '">Option ' + i.toString() + '</option>');
+
+                                    var group = Math.floor(j / 10) + 1;
+                                    var number = j % 10 + 1;
+                                    if (number === 1) {
+                                        $('#example-large-includeSelectAllOption-enableFiltering-enableClickableOptGroups').append('<optgroup label="Group ' + group.toString() + '"></optgroup>');
                                     }
-                                    else {
-                                        $('#example-large-includeSelectAllOption').html('');
-                                        $('#example-large-includeSelectAllOption-enableFiltering').html('');
-                                        $('#example-large-includeSelectAllOption-enableFiltering-enableClickableOptGroups').html('');
-                                        $('#example-large-reset').html('');
-                                        
-                                        for (var j = 0; j < options; j++) {
-                                            i = j + 1;
-                                            $('#example-large-includeSelectAllOption').append('<option value="' + i.toString() + '">Option ' + i.toString() + '</option>');
-                                            $('#example-large-includeSelectAllOption-enableFiltering').append('<option value="' + i.toString() + '">Option ' + i.toString() + '</option>');
-                                            
-                                            var group = Math.floor(j/10) + 1;
-                                            var number = j % 10 + 1;
-                                            if (number === 1) {
-                                                $('#example-large-includeSelectAllOption-enableFiltering-enableClickableOptGroups').append('<optgroup label="Group ' + group.toString() + '"></optgroup>');
-                                            }
-                                            $('#example-large-includeSelectAllOption-enableFiltering-enableClickableOptGroups').append('<option value="' + group.toString() + '-' + number.toString() + '">Option ' + group.toString() + '.' + number.toString() + '</option>');
-                                            
-                                            $('#example-large-reset').append('<option value="' + i.toString() + '">Option ' + i.toString() + '</option>');
-                                        }
+                                    $('#example-large-includeSelectAllOption-enableFiltering-enableClickableOptGroups').append('<option value="' + group.toString() + '-' + number.toString() + '">Option ' + group.toString() + '.' + number.toString() + '</option>');
 
-                                        $('#example-large-includeSelectAllOption').multiselect({
-                                            maxHeight: 200,
-                                            includeSelectAllOption: true
-                                        });
+                                    $('#example-large-reset').append('<option value="' + i.toString() + '">Option ' + i.toString() + '</option>');
+                                }
 
-                                        $('#example-large-includeSelectAllOption-enableFiltering').multiselect({
-                                            maxHeight: 200,
-                                            includeSelectAllOption: true,
-                                            enableFiltering: true
-                                        });
-
-                                        $('#example-large-includeSelectAllOption-enableFiltering-enableClickableOptGroups').multiselect({
-                                            maxHeight: 200,
-                                            includeSelectAllOption: true,
-                                            enableFiltering: true,
-                                            enableClickableOptGroups: true
-                                        });
-
-                                        $('#example-large-reset').multiselect({
-                                            maxHeight: 200,
-                                            includeSelectAllOption: true
-                                        });
-
-                                        $('#example-large-reset-form').on('reset', function() {
-                                            $('#example-large-reset').multiselect('deselectAll', false);
-                                            $('#example-large-reset').multiselect('updateButtonText');
-                                        });
-                                    }
+                                $('#example-large-includeSelectAllOption').multiselect({
+                                    maxHeight: 200,
+                                    includeSelectAllOption: true
                                 });
-                            });
-                        </script>
-                        <div class="btn-toolbar" style="margin-bottom:12px;">
-                            <div class="btn-group">
-                                <select id="example-large-includeSelectAllOption" multiple="multiple">
-                                    <option value="1">Option 1</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="btn-toolbar" style="margin-bottom:12px;">
-                            <div class="btn-group">
-                                <select id="example-large-includeSelectAllOption-enableFiltering" multiple="multiple">
-                                    <option value="1">Option 1</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="btn-toolbar" style="margin-bottom:12px;">
-                            <div class="btn-group">
-                                <select id="example-large-includeSelectAllOption-enableFiltering-enableClickableOptGroups" multiple="multiple">
-                                    <option value="1">Option 1</option>
-                                </select>
-                            </div>
-                        </div>
-                        <form id="example-large-reset-form" style="margin-bottom:12px;">
-                            <div class="btn-group">
-                                <select id="example-large-reset" multiple="multiple">
-                                    <option value="1">Option 1</option>
-                                </select>
-                                <button type="reset" class="btn btn-default">Reset</button>
-                            </div>
-                        </form>
+
+                                $('#example-large-includeSelectAllOption-enableFiltering').multiselect({
+                                    maxHeight: 200,
+                                    includeSelectAllOption: true,
+                                    enableFiltering: true
+                                });
+
+                                $('#example-large-includeSelectAllOption-enableFiltering-enableClickableOptGroups').multiselect({
+                                    maxHeight: 200,
+                                    includeSelectAllOption: true,
+                                    enableFiltering: true,
+                                    enableClickableOptGroups: true
+                                });
+
+                                $('#example-large-reset').multiselect({
+                                    maxHeight: 200,
+                                    includeSelectAllOption: true
+                                });
+
+                                $('#example-large-reset-form').on('reset', function () {
+                                    $('#example-large-reset').multiselect('deselectAll', false);
+                                    $('#example-large-reset').multiselect('updateButtonText');
+                                });
+                            }
+                        });
+                    });
+                </script>
+                <div class="btn-toolbar" style="margin-bottom:12px;">
+                    <div class="btn-group">
+                        <select id="example-large-includeSelectAllOption" multiple="multiple">
+                            <option value="1">Option 1</option>
+                        </select>
                     </div>
-                    <div class="highlight">
+                </div>
+                <div class="btn-toolbar" style="margin-bottom:12px;">
+                    <div class="btn-group">
+                        <select id="example-large-includeSelectAllOption-enableFiltering" multiple="multiple">
+                            <option value="1">Option 1</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="btn-toolbar" style="margin-bottom:12px;">
+                    <div class="btn-group">
+                        <select id="example-large-includeSelectAllOption-enableFiltering-enableClickableOptGroups"
+                                multiple="multiple">
+                            <option value="1">Option 1</option>
+                        </select>
+                    </div>
+                </div>
+                <form id="example-large-reset-form" style="margin-bottom:12px;">
+                    <div class="btn-group">
+                        <select id="example-large-reset" multiple="multiple">
+                            <option value="1">Option 1</option>
+                        </select>
+                        <button type="reset" class="btn btn-default">Reset</button>
+                    </div>
+                </form>
+            </div>
+            <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
@@ -4838,41 +5055,45 @@
     &lt;/div&gt;
 &lt;/form&gt;
 </pre>
-                    </div>
-                    
-                    <p>The following examples is aimed to demonstrate the performance of the <code>.multiselect('dataprovider', data)</code> for a large number of options.</p>
-                    
-                    <p class="alert alert-warning">The below examples need to be activated. <b>Note that this may take some time!</b></p>
-                    
-                    <p class="alert alert-info"><button id="example-large-dataprovider-button" class="btn btn-primary">Activate</button></p>
-                    
-                    <div class="example">
-                        <script type="text/javascript">
-                            $(document).ready(function() {
-                                var data = [];
-                                for (var i = 0; i < 100; i++) {
-                                    var group = {label: 'Group ' + (i + 1), children: []};
-                                    for (var j = 0; j < 10; j++) {
-                                        group['children'].push({
-                                            label: 'Option ' + (i + 1) + '.' + (j + 1),
-                                            value: i + '-' + j
-                                        });
-                                    }
-                                    
-                                    data.push(group);
-                                }
-                                
-                                $('#example-large-dataprovider-button').on('click', function() {
-                                    $('#example-large-dataprovider').multiselect({
-                                        maxHeight: 200
-                                    });
-                                    $('#example-large-dataprovider').multiselect('dataprovider', data);
+            </div>
+
+            <p>The following examples is aimed to demonstrate the performance of the <code>.multiselect('dataprovider',
+                data)</code> for a large number of options.</p>
+
+            <p class="alert alert-warning">The below examples need to be activated. <b>Note that this may take some
+                time!</b></p>
+
+            <p class="alert alert-info">
+                <button id="example-large-dataprovider-button" class="btn btn-primary">Activate</button>
+            </p>
+
+            <div class="example">
+                <script type="text/javascript">
+                    $(document).ready(function () {
+                        var data = [];
+                        for (var i = 0; i < 100; i++) {
+                            var group = {label: 'Group ' + (i + 1), children: []};
+                            for (var j = 0; j < 10; j++) {
+                                group['children'].push({
+                                    label: 'Option ' + (i + 1) + '.' + (j + 1),
+                                    value: i + '-' + j
                                 });
+                            }
+
+                            data.push(group);
+                        }
+
+                        $('#example-large-dataprovider-button').on('click', function () {
+                            $('#example-large-dataprovider').multiselect({
+                                maxHeight: 200
                             });
-                        </script>
-                        <select id="example-large-dataprovider" multiple="multiple"></select>
-                    </div>
-                    <div class="highlight">
+                            $('#example-large-dataprovider').multiselect('dataprovider', data);
+                        });
+                    });
+                </script>
+                <select id="example-large-dataprovider" multiple="multiple"></select>
+            </div>
+            <div class="highlight">
 <pre class="prettyprint linenums">
 $(document).ready(function() {
     var data = [];
@@ -4898,104 +5119,111 @@ $(document).ready(function() {
 &lt;p class=&quot;alert alert-info&quot;&gt;&lt;button id=&quot;example-large-dataprovider-button&quot; class=&quot;btn btn-primary&quot;&gt;Activate&lt;/button&gt;&lt;/p&gt;
 &lt;select id=&quot;example-large-dataprovider&quot; multiple=&quot;multiple&quot;&gt;&lt;/select&gt;
 </pre>
-                    
-                    <p>
-                        The following example illsutrates how to disable options using JavaScript.
-                    </p>
-                    
-                    <div class="example">
-                        <script type="text/javascript">
-                            $(document).ready(function() {
-                                $('#example-disable-javascript').multiselect({
-                                    includeSelectAllOption: true
-                                });
 
-                                $('#example-disable-javascript-disable').on('click', function() {
-                                    var input = $('#example-disable-javascript-container input[value="3"]');
-                                    var option = $('#example-disable-javascript-container option[value="3"]');
+                <p>
+                    The following example illsutrates how to disable options using JavaScript.
+                </p>
 
-                                    input.prop('disabled', true);
-                                    option.prop('disabled', true);
-
-                                    input.parent('label').parent('a').parent('li').addClass('disabled');
-                                });
-
-                                $('#example-disable-javascript-check').on('click', function() {
-                                    var options = '';
-                                    $('#example-disable-javascript option:selected').each(function() {
-                                        options += $(this).val() + ', ';
-                                    });
-
-                                    alert(options.substr(0, options.length - 2));
-                                });
+                <div class="example">
+                    <script type="text/javascript">
+                        $(document).ready(function () {
+                            $('#example-disable-javascript').multiselect({
+                                includeSelectAllOption: true
                             });
-                        </script>
-                        <div class="btn-group" id="example-disable-javascript-container">
-                            <select id="example-disable-javascript" multiple="multiple">
-                                <option value="1">Option 1</option>
-                                <option value="2">Option 2</option>
-                                <option value="3">Option 3</option>
-                                <option value="4">Option 4</option>
-                                <option value="5">Option 5</option>
-                                <option value="6">Option 6</option>
-                            </select>
-                            <button id="example-disable-javascript-disable" class="btn btn-primary">Disable an option!</button>
-                            <button id="example-disable-javascript-check" class="btn btn-primary">Check</button>
-                        </div>
+
+                            $('#example-disable-javascript-disable').on('click', function () {
+                                var input = $('#example-disable-javascript-container input[value="3"]');
+                                var option = $('#example-disable-javascript-container option[value="3"]');
+
+                                input.prop('disabled', true);
+                                option.prop('disabled', true);
+
+                                input.parent('label').parent('a').parent('li').addClass('disabled');
+                            });
+
+                            $('#example-disable-javascript-check').on('click', function () {
+                                var options = '';
+                                $('#example-disable-javascript option:selected').each(function () {
+                                    options += $(this).val() + ', ';
+                                });
+
+                                alert(options.substr(0, options.length - 2));
+                            });
+                        });
+                    </script>
+                    <div class="btn-group" id="example-disable-javascript-container">
+                        <select id="example-disable-javascript" multiple="multiple">
+                            <option value="1">Option 1</option>
+                            <option value="2">Option 2</option>
+                            <option value="3">Option 3</option>
+                            <option value="4">Option 4</option>
+                            <option value="5">Option 5</option>
+                            <option value="6">Option 6</option>
+                        </select>
+                        <button id="example-disable-javascript-disable" class="btn btn-primary">Disable an option!
+                        </button>
+                        <button id="example-disable-javascript-check" class="btn btn-primary">Check</button>
                     </div>
-                    <div class="highlight">
+                </div>
+                <div class="highlight">
 <pre class="prettyprint linenums">
 $(document).ready(function() {
     $('#example-disable-javascript').multiselect();
 });
 &lt;select id=&quot;example-disable-javascript&quot; multiple=&quot;multiple&quot;&gt;&lt;/select&gt;
 </pre>
-                        
+
                     <p>
-                        Performance example for using <code>.multiselect('refresh')</code> with a large number of options:
+                        Performance example for using <code>.multiselect('refresh')</code> with a large number of
+                        options:
                     </p>
 
-                    <p class="alert alert-warning">The below examples need to be activated. <b>Note that this may take some time!</b></p>
-                    
-                    <p class="alert alert-info"><button id="example-large-refresh-button" class="btn btn-primary">Activate</button></p>
-                    
+                    <p class="alert alert-warning">The below examples need to be activated. <b>Note that this may take
+                        some time!</b></p>
+
+                    <p class="alert alert-info">
+                        <button id="example-large-refresh-button" class="btn btn-primary">Activate</button>
+                    </p>
+
                     <div class="example">
                         <script type="text/javascript">
-                            $(document).ready(function() {
-                                $('#example-large-refresh-button').on('click', function() {
+                            $(document).ready(function () {
+                                $('#example-large-refresh-button').on('click', function () {
                                     for (var i = 0; i < 1000; i++) {
                                         $('#example-large-refresh').append('<option value="' + i + '">Option ' + i + '</option>');
                                     }
-                                    
+
                                     $('#example-large-refresh').multiselect();
                                 });
-                                
-                                $('#example-large-refresh-refresh').on('click', function() {
+
+                                $('#example-large-refresh-refresh').on('click', function () {
                                     $('#example-large-refresh').multiselect('refresh');
                                 });
-                                
-                                $('#example-large-refresh-select').on('click', function() {
+
+                                $('#example-large-refresh-select').on('click', function () {
                                     var count = 0;
-                                    
-                                    $('#example-large-refresh option').each(function() {
+
+                                    $('#example-large-refresh option').each(function () {
                                         var i = $(this).val();
-                                        
-                                        if (i%2 == 0) {
+
+                                        if (i % 2 == 0) {
                                             $(this).prop('selected', true);
                                             count++;
                                         }
-                                        
+
                                     });
-                                    
+
                                     alert('Selected ' + count + ' options!');
                                 });
                             });
                         </script>
                         <div class="btn-group">
                             <select id="example-large-refresh" multiple="multiple">
-                                
+
                             </select>
-                            <button id="example-large-refresh-select" class="btn btn-default">Select every second option ...</button>
+                            <button id="example-large-refresh-select" class="btn btn-default">Select every second option
+                                ...
+                            </button>
                             <button id="example-large-refresh-refresh" class="btn btn-primary">Refresh!</button>
                         </div>
                     </div>
@@ -5034,22 +5262,31 @@ $(document).ready(function() {
 &lt;/script&gt;
 </pre>
                     </div>
-                        
+
                     <div class="page-header">
                         <h2 id="post">Server-Side Processing</h2>
                     </div>
-                    
+
                     <p class="alert alert-warning">
-                        The below example uses a PHP script to demonstrate Server-Side Processing. Therefore, the below example will not run online - <b>download the repository and try it on a local server</b>.
+                        The below example uses a PHP script to demonstrate Server-Side Processing. Therefore, the below
+                        example will not run online - <b>download the repository and try it on a local server</b>.
                     </p>
-                    
+
                     <p>
-                        In order to receive the correct data after submitting the form, the used <code>select</code> has to have an appropriate name. Note that an <code>[]</code> needs to be appended to the name when using the <code>multiple</code> option/attribute. Per default, the checkboxes used within the multiselect will not be submitted, however, this can be changed by adapting <code>checkboxName</code>. The select all option as well as the text input used for the filter will not be submitted. As this may be useful, the name of the select all checkbox may be adapted using the <code>selectAllName</code> option. The value of the select all checkbox can be controlled by the <code>selectAllValue</code> option while the values of the remaining checkboxes correspond to the values used by the <code>option</code>'s of the original <code>select</code>.
+                        In order to receive the correct data after submitting the form, the used <code>select</code> has
+                        to have an appropriate name. Note that an <code>[]</code> needs to be appended to the name when
+                        using the <code>multiple</code> option/attribute. Per default, the checkboxes used within the
+                        multiselect will not be submitted, however, this can be changed by adapting
+                        <code>checkboxName</code>. The select all option as well as the text input used for the filter
+                        will not be submitted. As this may be useful, the name of the select all checkbox may be adapted
+                        using the <code>selectAllName</code> option. The value of the select all checkbox can be
+                        controlled by the <code>selectAllValue</code> option while the values of the remaining
+                        checkboxes correspond to the values used by the <code>option</code>'s of the original <code>select</code>.
                     </p>
-                    
+
                     <div class="example">
                         <script type="text/javascript">
-                            $(document).ready(function() {
+                            $(document).ready(function () {
                                 $('#example-post').multiselect({
                                     includeSelectAllOption: true,
                                     enableFiltering: true
@@ -5059,6 +5296,7 @@ $(document).ready(function() {
                         <form class="form-horizontal" method="POST" action="post.php">
                             <div class="form-group">
                                 <label class="col-sm-2 control-label">Multiselect</label>
+
                                 <div class="col-sm-10">
                                     <select id="example-post" name="multiselect[]" multiple="multiple">
                                         <option value="1">Option 1</option>
@@ -5072,8 +5310,9 @@ $(document).ready(function() {
                             </div>
                             <div class="form-group">
                                 <label class="col-sm-2 control-label">Text Input</label>
+
                                 <div class="col-sm-10">
-                                    <input type="text" name="text" class="form-control" placeholder="Text Input" />
+                                    <input type="text" name="text" class="form-control" placeholder="Text Input"/>
                                 </div>
                             </div>
                             <div class="form-group">
@@ -5167,83 +5406,125 @@ $(document).ready(function() {
 &lt;/form&gt;
 </pre>
                     </div>
-                    
+
                     <div class="page-header">
                         <h2 id="keyboard-support">Keyboard Support</h2>
                     </div>
-                    
+
                     <table class="table table-striped">
                         <tbody>
-                            <tr>
-                                <td><code>Tab</code></td>
-                                <td>As with other form elements, <code>Tab</code> is used to switch to the next form elements. <code>Tab</code> can be used when the dropdown is opened as well as when it is closed.</td>
-                            </tr>
-                            <tr>
-                                <td><code>Space/Enter</code></td>
-                                <td><code>Space</code> or <code>Enter</code> is used to open the dropdown and select options. After a multiselect is in focus, pressing <code>Space</code> or <code>Enter</code> will open the dropdown. Then, the options can be traversed using arrow up and down.</td>
-                            </tr>
-                            <tr>
-                                <td><code>Arrow Up/Arrow Down</code></td>
-                                <td>Used to traverse the options after opening the dropdown. An option can be selected using <code>Space</code> or <code>Enter</code>.</td>
-                            </tr>
+                        <tr>
+                            <td><code>Tab</code></td>
+                            <td>As with other form elements, <code>Tab</code> is used to switch to the next form
+                                elements. <code>Tab</code> can be used when the dropdown is opened as well as when it is
+                                closed.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>Space/Enter</code></td>
+                            <td><code>Space</code> or <code>Enter</code> is used to open the dropdown and select
+                                options. After a multiselect is in focus, pressing <code>Space</code> or
+                                <code>Enter</code> will open the dropdown. Then, the options can be traversed using
+                                arrow up and down.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>Arrow Up/Arrow Down</code></td>
+                            <td>Used to traverse the options after opening the dropdown. An option can be selected using
+                                <code>Space</code> or <code>Enter</code>.
+                            </td>
+                        </tr>
                         </tbody>
                     </table>
-                    
+
                     <div class="page-header">
                         <h2 id="faq">Frequently Asked Questions</h2>
                     </div>
-                    
+
                     <dl>
                         <dt id="how-to-contribute">How to contribute?</dt>
                         <dd>
-                            Pull requests to add additional feature or fix known bugs are always welcome! However, to make it easy for me to review and merge your pull request, the following guidelines should be considered:
+                            Pull requests to add additional feature or fix known bugs are always welcome! However, to
+                            make it easy for me to review and merge your pull request, the following guidelines should
+                            be considered:
                             <ul>
-                                <li>Add one pull request per feature/fix. Otherwise, I cannot guarantee that I will merge the pull request.</li>
-                                <li>Always document your changes. If new features are added, new options or methods should be added to the documentation (<code>index.html</code>) and appropriate examples should be added.</li>
-                                <li>Add a throrough description to your pull request - yes, I am able to read your code, however, reading your description may speed up things!</li>
+                                <li>Add one pull request per feature/fix. Otherwise, I cannot guarantee that I will
+                                    merge the pull request.
+                                </li>
+                                <li>Always document your changes. If new features are added, new options or methods
+                                    should be added to the documentation (<code>index.html</code>) and appropriate
+                                    examples should be added.
+                                </li>
+                                <li>Add a throrough description to your pull request - yes, I am able to read your code,
+                                    however, reading your description may speed up things!
+                                </li>
                                 <li>Add comments to your code.</li>
                             </ul>
-                            A full list of contributors can be found <a href="https://github.com/davidstutz/bootstrap-multiselect/graphs/contributors">here</a>.
+                            A full list of contributors can be found <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/graphs/contributors">here</a>.
                         </dd>
-                        
+
                         <dt>How about older browsers as for example Internet Explorer 6, 7 and 8?</dt>
                         <dd>
-                            With version 2.0, jQuery no longer supports the older IE versions. Nevertheless, the plugin should run as expected using the 1.x branch of jQuery. See <a href="http://blog.jquery.com/2013/04/18/jquery-2-0-released/">here</a> for details.
+                            With version 2.0, jQuery no longer supports the older IE versions. Nevertheless, the plugin
+                            should run as expected using the 1.x branch of jQuery. See <a
+                                href="http://blog.jquery.com/2013/04/18/jquery-2-0-released/">here</a> for details.
                         </dd>
-                        
-                        <dt>May I use the plugin in a commercial project (e.g. a commercial Wordpress/Joomla theme)?</dt>
+
+                        <dt>May I use the plugin in a commercial project (e.g. a commercial Wordpress/Joomla theme)?
+                        </dt>
                         <dd>
-                            The plugin is dual licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License v2.0</a> and the <a href="http://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause License</a>. The BSD 3-Clause License allows to use the plugin in commercial projects as long as all source files associated with this plugin retain the copyright notice.
+                            The plugin is dual licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache
+                            License v2.0</a> and the <a href="http://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause
+                            License</a>. The BSD 3-Clause License allows to use the plugin in commercial projects as
+                            long as all source files associated with this plugin retain the copyright notice.
                         </dd>
-                        
-                        <dt>Using <code>return false;</code> within the <code>onChange</code> option does not prevent the option from being selected/deselected ...</dt>
+
+                        <dt>Using <code>return false;</code> within the <code>onChange</code> option does not prevent
+                            the option from being selected/deselected ...
+                        </dt>
                         <dd>
-                            The <code>return</code> statement within the <code>onChange</code> method has no influence on the result. For preventing an option from being deselected or selected have a look at the examples in the <a href="#further-examples">Further Examples</a> section.
+                            The <code>return</code> statement within the <code>onChange</code> method has no influence
+                            on the result. For preventing an option from being deselected or selected have a look at the
+                            examples in the <a href="#further-examples">Further Examples</a> section.
                         </dd>
-                        
+
                         <dt>How to change the button class depending on the number of selected options?</dt>
                         <dd>
-                            This issue is addressed in <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/332">332</a>.
+                            This issue is addressed in <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/332">332</a>.
                         </dd>
-                        
-                        <dt>Why does the plugin crash when using <code>.multiselect('select', value);</code> or <code>.multiselect('deselect', value);</code>?</dt>
+
+                        <dt>Why does the plugin crash when using <code>.multiselect('select', value);</code> or <code>.multiselect('deselect',
+                            value);</code>?
+                        </dt>
                         <dd>
-                            This may be caused when the class used for the <code>select</code> occurs for other elements, as well. In addition this may be caused if the multiselect has the class <code>.multiselect</code>. See <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/330">#330</a>.
+                            This may be caused when the class used for the <code>select</code> occurs for other
+                            elements, as well. In addition this may be caused if the multiselect has the class <code>.multiselect</code>.
+                            See <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/330">#330</a>.
                         </dd>
-                        
-                        <dt>How to check whether filtering all options resulted no options being displayed (except the select all option)?</dt>
+
+                        <dt>How to check whether filtering all options resulted no options being displayed (except the
+                            select all option)?
+                        </dt>
                         <dd>
-                            This issue is discussed in <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/317">#317</a>.
+                            This issue is discussed in <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/317">#317</a>.
                         </dd>
-                        
+
                         <dt>How to use multiple plugin instances running single selections on one page?</dt>
                         <dd>
-                            There is a minor bug when using multiple plugin instances with single selection on one page. The bug is described here: <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/331">#331</a>. A possible fix is suggested here: <a href="https://github.com/davidstutz/bootstrap-multiselect/pull/336">#336</a>.
+                            There is a minor bug when using multiple plugin instances with single selection on one page.
+                            The bug is described here: <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/331">#331</a>. A
+                            possible fix is suggested here: <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/pull/336">#336</a>.
                         </dd>
-                        
+
                         <dt>How to use the plugin within a <code>form.form-inline</code>?</dt>
                         <dd>
-                            This issue is addressed in <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/322">#322</a>
+                            This issue is addressed in <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/322">#322</a>
                         </dd>
 
                         <dt>Using jQuery, how to get the selected options dynamically?</dt>
@@ -5259,105 +5540,138 @@ $('#example option:selected').map(function(a, item){return item.value;});
 
                         <dt>How to get the selected options using PHP?</dt>
                         <dd>
-                            This issue is addressed here: <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/323">https://github.com/davidstutz/bootstrap-multiselect/issues/323</a>. Mainly there are two ways, either add a name to the <code>select</code>:
+                            This issue is addressed here: <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/323">https://github.com/davidstutz/bootstrap-multiselect/issues/323</a>.
+                            Mainly there are two ways, either add a name to the <code>select</code>:
 <pre class="linenums prettyprint">
 &lt;select id="example2" multiple="multiple" name="select[]"&gt;&lt;/select&gt;
 </pre>
-                        <p>Or add an appropriate name to the checkboxes:</p>
+                            <p>Or add an appropriate name to the checkboxes:</p>
 <pre class="linenums prettyprint">
 $('#example2').multiselect({
     checkboxName: 'multiselect[]'
 });
 </pre>
                         </dd>
-                        
+
                         <dt>Why does the plugin not work in Chrome for Mobile?</dt>
                         <dd>
-                            This may be caused by several reasons one of which is described and resolved here: <a href="https://github.com/davidstutz/bootstrap-multiselect/pull/223">#223</a>.
+                            This may be caused by several reasons one of which is described and resolved here: <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/pull/223">#223</a>.
                         </dd>
-                        
+
                         <dt>How to underline the searched text when using the filter?</dt>
                         <dd>
-                            This issue is discussed in <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/309">#309</a>.
+                            This issue is discussed in <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/309">#309</a>.
                         </dd>
-                        
+
                         <dt>How to hide the checkboxes?</dt>
                         <dd>
-                            A related issue is discussed in <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/205">#205</a> and includes a possible solution when using CSS to hide the checkboxes:
+                            A related issue is discussed in <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/205">#205</a> and
+                            includes a possible solution when using CSS to hide the checkboxes:
 <pre class="prettyprint linenums">
 .multiselect-container input {
     display: none
 }
 </pre>
                         </dd>
-                        
+
                         <dt>How to use Bootstrap Multiselect using <code>$.validate</code>?</dt>
                         <dd>
-                            This topic is discussed in issue <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/347">#347</a>. The fix suggested is as follows:
+                            This topic is discussed in issue <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/347">#347</a>. The fix
+                            suggested is as follows:
 <pre class="prettyprint linenums">
 var $form = $("#myForm");
 var validator = $form.data('validator');
 validator.settings.ignore = ':hidden:not(".multiselect")';
 </pre>
                         </dd>
-                        
+
                         <dt>How to prevent the plugin from selecting the first option in single select mode?</dt>
                         <dd>
-                            This issue is mainly due to the default behavior of most browsers. A workaround can be found here: <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/129">#129</a>.
+                            This issue is mainly due to the default behavior of most browsers. A workaround can be found
+                            here: <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/129">#129</a>.
                         </dd>
-                        
-                        <dt>Which are the minimum required components of Twitter Botostrap to get the plugin working?</dt>
+
+                        <dt>Which are the minimum required components of Twitter Botostrap to get the plugin working?
+                        </dt>
                         <dd>
-                            The plugin needs at least the styles for forms and dropdowns. In addition the JavaScript dropdown plugin from Twitter Bootstrap is required. Details can be found here: <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/344">#344</a>.
+                            The plugin needs at least the styles for forms and dropdowns. In addition the JavaScript
+                            dropdown plugin from Twitter Bootstrap is required. Details can be found here: <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/344">#344</a>.
                         </dd>
-                        
+
                         <dt>How to use the <code>.multiselect('dataprovider', data)</code> method?</dt>
                         <dd>
-                            Have a look at the <a href="#methods">Methods</a> section. In the past, there has been some confusion about how the method handles option groups. If the documentation does not help you, have a look at the issue tracker, as for example issue <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/356">#356</a>.
+                            Have a look at the <a href="#methods">Methods</a> section. In the past, there has been some
+                            confusion about how the method handles option groups. If the documentation does not help
+                            you, have a look at the issue tracker, as for example issue <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/356">#356</a>.
                         </dd>
-                        
+
                         <dt>A <code>type="reset"</code> button does not refresh the multiselect, what to do?</dt>
                         <dd>
-                            Have a look at the <a href="#further-examples">Further Examples</a> section (in addition, issue <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/360">360</a> discussed this).
+                            Have a look at the <a href="#further-examples">Further Examples</a> section (in addition,
+                            issue <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/360">360</a>
+                            discussed this).
                         </dd>
-                        
-                        <dt>Using multiple <code>select</code>'s in single selection mode with <code>option</code>'s sharing values across the different <code>select</code>'s.</dt>
+
+                        <dt>Using multiple <code>select</code>'s in single selection mode with <code>option</code>'s
+                            sharing values across the different <code>select</code>'s.
+                        </dt>
                         <dd>
-                            This issue is discussed in detail here: <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/362">#362</a>. A simple solution is to use different option values for the option <code>checkboxName</code>:
+                            This issue is discussed in detail here: <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/362">#362</a>. A simple
+                            solution is to use different option values for the option <code>checkboxName</code>:
 <pre class="prettyprint linenums">
 $('.multiselect').multiselect({
     checkboxName: _.uniqueId('multiselect_')
 });
 </pre>
-                            where <code>_.uniqueId('multiselect_')</code> should be replaced with a random generator. Alternatively, a unique value for <code>checkboxName</code> can be used for each multiselect.
+                            where <code>_.uniqueId('multiselect_')</code> should be replaced with a random generator.
+                            Alternatively, a unique value for <code>checkboxName</code> can be used for each
+                            multiselect.
                         </dd>
-                        
+
                         <dt>How to avoid <code>TypeError: Cannot read property "toString" of ...</code>?</dt>
                         <dd>
-                            This error may be thrown if <code>null</code> or <code>undefined</code> is provided as argument of <code>.multiselect('select', value)</code> or <code>.multiselect('deselect', value)</code>, see <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/386">#386</a>.
+                            This error may be thrown if <code>null</code> or <code>undefined</code> is provided as
+                            argument of <code>.multiselect('select', value)</code> or <code>.multiselect('deselect',
+                            value)</code>, see <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/386">#386</a>.
                         </dd>
-                        
+
                         <dt>Why is there no "uncheck all" option?</dt>
                         <dd>
-                            This issue is discussed in <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/271">#271.</a>
+                            This issue is discussed in <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/271">#271.</a>
                         </dd>
-                        
+
                         <dt>Esc does not close the dropdown?!</dt>
                         <dd>
-                            This issue is discussed in <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/368">#368</a>. Currently, pressing <code>Esc</code> will not close the dropdown as there were some bugs with this.
+                            This issue is discussed in <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/368">#368</a>.
+                            Currently, pressing <code>Esc</code> will not close the dropdown as there were some bugs
+                            with this.
                         </dd>
-                        
+
                         <dt>How to keep the dropdown open?</dt>
                         <dd>
-                            This issue is discussed here: <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/426">#426</a>.
+                            This issue is discussed here: <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/426">#426</a>.
                         </dd>
-                        
+
                         <dt>Why is the dropdown not showing (or only partly shown) within modals?</dt>
                         <dd>
-                            This is a general issue not directly related to Bootstrap Multiselect: <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/455">#455</a>.
+                            This is a general issue not directly related to Bootstrap Multiselect: <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/455">#455</a>.
                         </dd>
-                        
-                        <dt>How do add icons to the options (<a href="https://github.com/davidstutz/bootstrap-multiselect/issues/475">#475</a>)?</dt>
+
+                        <dt>How do add icons to the options (<a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/475">#475</a>)?
+                        </dt>
                         <dd>
                             Adapt the <code>optionLabel</code> option as follows:
 <pre class="prettyprint linenums">
@@ -5366,85 +5680,116 @@ optionLabel: function(element){
 },
 </pre>
                         </dd>
-                        
+
                         <dt>How to add a deselect all functionality (the inverse to the select all option)?</dt>
                         <dd>
-                            This issue was discussed in the following pull request: <a href="https://github.com/davidstutz/bootstrap-multiselect/pull/487">#487</a>.
+                            This issue was discussed in the following pull request: <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/pull/487">#487</a>.
                         </dd>
-                        
+
                         <dt>How to bind object values using Knockout JS?</dt>
                         <dd>
-                            This issue was discussed in <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/532">#532</a>.
+                            This issue was discussed in <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/532">#532</a>.
                         </dd>
-                        
+
                         <dt>Options do net get updated when using Angular JS?</dt>
                         <dd>
-                            This issues was discussed in <a href="https://github.com/davidstutz/bootstrap-multiselect/pull/519">#519</a>.
+                            This issues was discussed in <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/pull/519">#519</a>.
                         </dd>
-                        
+
                         <dt>Is there a search event?</dt>
                         <dd>
-                            This was discussed here: <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/530">#530</a>.
+                            This was discussed here: <a
+                                href="https://github.com/davidstutz/bootstrap-multiselect/issues/530">#530</a>.
                         </dd>
                     </dl>
-                    
+
                     <div class="page-header">
                         <h2 id="known-issues">Known Issues</h2>
                     </div>
-                    
+
                     <dl>
                         <dt>Slow dropdown on Chrome 35.</dt>
                         <dd>
-                            As discussed in <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/268">#268</a>, certain versions seem to have some performance problems, especially Chrome 35.0.1916.114m.
+                            As discussed in <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/268">#268</a>,
+                            certain versions seem to have some performance problems, especially Chrome 35.0.1916.114m.
                         </dd>
-                        
+
                         <dt>Using <code>maxHeight</code> results in the filter being not fixed at the top.</dt>
                         <dd>
-                            See issue <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/396"></a>. Pull requests are welcome.
+                            See issue <a href="https://github.com/davidstutz/bootstrap-multiselect/issues/396"></a>.
+                            Pull requests are welcome.
                         </dd>
                     </dl>
-                    
+
                     <div class="page-header">
                         <h2 id="license">License</h2>
                     </div>
-                    
+
                     <dl>
                         <dt>Apache License, Version 2.0</dt>
                         <dd>
                             <p>Copyright 2012 - 2014 David Stutz</p>
+
                             <p>
-                                Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at <a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">http://www.apache.org/licenses/LICENSE-2.0</a>.
+                                Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+                                file except in compliance with the License. You may obtain a copy of the License at <a
+                                    href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">http://www.apache.org/licenses/LICENSE-2.0</a>.
                             </p>
+
                             <p>
-                                Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+                                Unless required by applicable law or agreed to in writing, software distributed under
+                                the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+                                KIND, either express or implied. See the License for the specific language governing
+                                permissions and limitations under the License.
                             </p>
                         </dd>
 
                         <dt>BSD 3-Clause License</dt>
                         <dd>
                             <p>Copyright (c) 2012 - 2014 David Stutz</p>
+
                             <p>All rights reserved.</p>
+
                             <p>
-                                Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+                                Redistribution and use in source and binary forms, with or without modification, are
+                                permitted provided that the following conditions are met:
                             </p>
                             <ul>
-                                <li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-                                <li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-                                <li>Neither the name of David Stutz nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+                                <li>Redistributions of source code must retain the above copyright notice, this list of
+                                    conditions and the following disclaimer.
+                                <li>Redistributions in binary form must reproduce the above copyright notice, this list
+                                    of conditions and the following disclaimer in the documentation and/or other
+                                    materials provided with the distribution.
+                                <li>Neither the name of David Stutz nor the names of its contributors may be used to
+                                    endorse or promote products derived from this software without specific prior
+                                    written permission.
                             </ul>
                             <p>
-                                THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+                                THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+                                EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+                                MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+                                THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+                                SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+                                OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+                                INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+                                LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+                                OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                             </p>
                         </dd>
                     </dl>
-                    
+
                     <hr>
                     <p>
                         &copy; 2012 - 2014
-                        <a href="http://davidstutz.de">David Stutz</a> - dual licensed: <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License v2.0</a>, <a href="http://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause License</a>
+                        <a href="http://davidstutz.de">David Stutz</a> - dual licensed: <a
+                            href="http://www.apache.org/licenses/LICENSE-2.0">Apache License v2.0</a>, <a
+                            href="http://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause License</a>
                     </p>
                 </div>
             </div>
         </div>
-    </body>
+</body>
 </html>


### PR DESCRIPTION
Hi, thanks for this awesome plugin !

I needed to filter options regardless of accents. So I added an option `enableReplaceDiacritics`. 

``````
$(document).ready(function () {
   $('#example-filter-enableReplaceDiacritics').multiselect({
        enableFiltering: true,
        enableReplaceDiacritics : true,
        enableCaseInsensitiveFiltering: true
    });
});
<select id="example-filter-enableReplaceDiacritics" multiple="multiple">
    <option value="a">Bière</option>
    <option value="b">birrë</option>
    <option value="c">Øl</option>
    <option value="d">pivə</option>
    <option value="e">Sör</option>
</select>```
``````
