### PR TITLE
ButtonWidth no longer sizes regressively when using percentages

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -443,7 +443,7 @@
             // Manually add button width if set.
             if (this.options.buttonWidth && this.options.buttonWidth !== 'auto') {
                 this.$button.css({
-                    'width' : this.options.buttonWidth,
+                    'width' : '100%',
                     'overflow' : 'hidden',
                     'text-overflow' : 'ellipsis'
                 });


### PR DESCRIPTION
Originally, if you were to set ButtonWidth: say 75%,
the outer container would be set to 75%, and the button group would be 75% of that. 

Now, it sets the outer container to whatever percentage, and the button group is 100% of that container.