### PR TITLE
add preFilter option to filter options when building multiselect

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "bootstrap-multiselect",
   "description": "Twitter Bootstrap plugin to make selects user friendly.",
   "homepage": "http://davidstutz.github.io/bootstrap-multiselect/",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "keywords": [
       "js",
       "css",

--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1008,6 +1008,69 @@
             }
         },
 
+        runFilter: function() {
+            this.query = this.query || '';
+            var currentGroup, currentGroupVisible;
+            $.each($('li', this.$ul), $.proxy(function(index, element) {
+                var value = $('input', element).length > 0 ? $('input', element).val() : "";
+                var text = $('label', element).text();
+
+                var filterCandidate = '';
+                if ((this.options.filterBehavior === 'text')) {
+                    filterCandidate = text;
+                }
+                else if ((this.options.filterBehavior === 'value')) {
+                    filterCandidate = value;
+                }
+                else if (this.options.filterBehavior === 'both') {
+                    filterCandidate = text + '\n' + value;
+                }
+
+                if (value !== this.options.selectAllValue && text) {
+
+                    // By default lets assume that element is not
+                    // interesting for this search.
+                    var showElement = false;
+
+                    if (this.options.enableCaseInsensitiveFiltering) {
+                        filterCandidate = filterCandidate.toLowerCase();
+                        this.query = this.query.toLowerCase();
+                    }
+
+                    if (this.options.enableFullValueFiltering && this.options.filterBehavior !== 'both') {
+                        var valueToMatch = filterCandidate.trim().substring(0, this.query.length);
+                        if (this.query.indexOf(valueToMatch) > -1) {
+                            showElement = true;
+                        }
+                    }
+                    else if (filterCandidate.indexOf(this.query) > -1) {
+                        showElement = true;
+                    }
+
+                    // Toggle current element (group or group item) according to showElement boolean.
+                    $(element).toggle(showElement).toggleClass('filter-hidden', !showElement);
+                    
+                    // Differentiate groups and group items.
+                    if ($(element).hasClass('multiselect-group')) {
+                        // Remember group status.
+                        currentGroup = element;
+                        currentGroupVisible = showElement;
+                    }
+                    else {
+                        // Show group name when at least one of its items is visible.
+                        if (showElement) {
+                            $(currentGroup).show().removeClass('filter-hidden');
+                        }
+                        
+                        // Show all group items when group name satisfies filter.
+                        if (!showElement && currentGroupVisible) {
+                            $(element).show().removeClass('filter-hidden');
+                        }
+                    }
+                }
+            }, this));
+        },
+
         /**
          * Builds the filter.
          */
@@ -1021,7 +1084,10 @@
 
                     this.$filter = $(this.options.templates.filter);
                     $('input', this.$filter).attr('placeholder', this.options.filterPlaceholder);
-                    
+                    if (this.options.preFilter) {
+                        $('input', this.$filter).val(this.options.preFilter);
+                    }
+
                     // Adds optional filter clear button
                     if(this.options.includeFilterClearBtn){
                         var clearBtn = $(this.options.templates.filterClearBtn);
@@ -1035,6 +1101,11 @@
                     }
                     
                     this.$ul.prepend(this.$filter);
+
+                    if (this.options.preFilter) {
+                        this.query = this.options.preFilter;
+                        this.runFilter();
+                    }
 
                     this.$filter.val(this.query).on('click', function(event) {
                         event.stopPropagation();
@@ -1051,66 +1122,7 @@
 
                             if (this.query !== event.target.value) {
                                 this.query = event.target.value;
-
-                                var currentGroup, currentGroupVisible;
-                                $.each($('li', this.$ul), $.proxy(function(index, element) {
-                                    var value = $('input', element).length > 0 ? $('input', element).val() : "";
-                                    var text = $('label', element).text();
-
-                                    var filterCandidate = '';
-                                    if ((this.options.filterBehavior === 'text')) {
-                                        filterCandidate = text;
-                                    }
-                                    else if ((this.options.filterBehavior === 'value')) {
-                                        filterCandidate = value;
-                                    }
-                                    else if (this.options.filterBehavior === 'both') {
-                                        filterCandidate = text + '\n' + value;
-                                    }
-
-                                    if (value !== this.options.selectAllValue && text) {
-
-                                        // By default lets assume that element is not
-                                        // interesting for this search.
-                                        var showElement = false;
-
-                                        if (this.options.enableCaseInsensitiveFiltering) {
-                                            filterCandidate = filterCandidate.toLowerCase();
-                                            this.query = this.query.toLowerCase();
-                                        }
-
-                                        if (this.options.enableFullValueFiltering && this.options.filterBehavior !== 'both') {
-                                            var valueToMatch = filterCandidate.trim().substring(0, this.query.length);
-                                            if (this.query.indexOf(valueToMatch) > -1) {
-                                                showElement = true;
-                                            }
-                                        }
-                                        else if (filterCandidate.indexOf(this.query) > -1) {
-                                            showElement = true;
-                                        }
-
-                                        // Toggle current element (group or group item) according to showElement boolean.
-                                        $(element).toggle(showElement).toggleClass('filter-hidden', !showElement);
-                                        
-                                        // Differentiate groups and group items.
-                                        if ($(element).hasClass('multiselect-group')) {
-                                            // Remember group status.
-                                            currentGroup = element;
-                                            currentGroupVisible = showElement;
-                                        }
-                                        else {
-                                            // Show group name when at least one of its items is visible.
-                                            if (showElement) {
-                                                $(currentGroup).show().removeClass('filter-hidden');
-                                            }
-                                            
-                                            // Show all group items when group name satisfies filter.
-                                            if (!showElement && currentGroupVisible) {
-                                                $(element).show().removeClass('filter-hidden');
-                                            }
-                                        }
-                                    }
-                                }, this));
+                                this.runFilter();
                             }
 
                             this.updateSelectAll();


### PR DESCRIPTION
I need to draw the multiselect with a filter already applied (for example, from query parameters).  I didn't see a way to do that right now.  This change checks `options.preFilter`, and if set applies filters to options when building the multiselect.

Please take a look and let me know if this makes sense.  

