### PR TITLE
support passing a local jQuery reference

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1627,4 +1627,4 @@
         $("select[data-role=multiselect]").multiselect();
     });
 
-}(window.jQuery);
+}(window.jQuery || jQuery);


### PR DESCRIPTION
When use `bootstrap-multiselect` in [webpack](https://github.com/webpack/webpack), only local jQuery reference is available, this change is to support this case.
