### PR TITLE
Use of class keyword causes JS minification compiler to fail in CMS

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1424,12 +1424,12 @@
                 }
                 else {
                     $tag = $('<option/>').attr({
-                        value: option.value,
-                        label: option.label || option.value,
-                        title: option.title,
-                        class: option.class,
-                        selected: !!option.selected,
-                        disabled: !!option.disabled
+                        'value': option.value,
+                        'label': option.label || option.value,
+                        'title': option.title,
+                        'class': option['class'],
+                        'selected': !!option.selected,
+                        'disabled': !!option.disabled
                     });
                     $tag.text(option.label || option.value);
                 }


### PR DESCRIPTION
Hey,

First of all, thanks so much for this plugin. It's awesome. Integrating this plugin with Adobe AEM and minification of the clientlibs enabled cause the clientlibs to not compile anymore. Caused by the use of the 'class' keyword. 

I'll provide a fix by way of pull request. 

Cheers,

Marnix