### PR TITLE
Enable "Select all" button to fire onChange uncommenting lines

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -575,6 +575,9 @@
 
                 if (isSelectAllOption) {
                     
+                    //Select all firing change
+                    //this.options.onChange($option, checked);
+                    
                     if (checked) {
                         this.selectAll(this.options.selectAllJustVisible);
                     }


### PR DESCRIPTION
Added lines 578 and 579 commented:

//Select all firing change
//this.options.onChange($option, checked);

So anyone can uncomment this second line to make "Select all" button fire onChange.