### PR TITLE
SelectAll broken when more than one on a page

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1333,7 +1333,7 @@
                 }, this));
             }
 
-            $('li input[value="' + this.options.selectAllValue + '"]').prop('checked', true);
+            $('li input[value="' + this.options.selectAllValue + '"]', this.$ul).prop('checked', true);
 
             if (this.options.enableClickableOptGroups && this.options.multiple) {
                 this.updateOptGroups();
@@ -1378,7 +1378,7 @@
                 }, this));
             }
 
-            $('li input[value="' + this.options.selectAllValue + '"]').prop('checked', false);
+            $('li input[value="' + this.options.selectAllValue + '"]', this.$ul).prop('checked', false);
 
             if (this.options.enableClickableOptGroups && this.options.multiple) {
                 this.updateOptGroups();


### PR DESCRIPTION
When there are multiple instances on a page with select-all, ensure the select all action is limited to the specific control it was triggered on