### PR TITLE
fixed selectAll issue for multiple instances on single page

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1333,7 +1333,7 @@
                 }, this));
             }
 
-            $('li input[value="' + this.options.selectAllValue + '"]').prop('checked', true);
+            $('li input[value="' + this.options.selectAllValue + '"]', allLis).prop('checked', true);
 
             if (this.options.enableClickableOptGroups && this.options.multiple) {
                 this.updateOptGroups();
@@ -1378,7 +1378,7 @@
                 }, this));
             }
 
-            $('li input[value="' + this.options.selectAllValue + '"]').prop('checked', false);
+            $('li input[value="' + this.options.selectAllValue + '"]', allLis).prop('checked', false);
 
             if (this.options.enableClickableOptGroups && this.options.multiple) {
                 this.updateOptGroups();


### PR DESCRIPTION
This was suggested by another member. The issue was that when multiple instances of the plugin were existing in a single page, when choosing the Select All option of one instance would check the Select All option of all existing instances.