### PR TITLE
Advanced templates

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -444,9 +444,7 @@
                 li: '<li><a tabindex="0"><label></label></a></li>',
                 divider: '<li class="multiselect-item divider"></li>',
                 liGroup: '<li class="multiselect-item multiselect-group"><label></label></li>'
-            },
-            hideInputButton: false
-
+            }
         },
 
         constructor: Multiselect,
@@ -884,11 +882,7 @@
             if (name) {
                 $checkbox.attr('name', name);
             }
-          
-           if(this.options.hideInputButton){
-                $checkbox.css("display", "none");
-                $label.css("padding-left", "10px");
-           }
+
             $label.prepend($checkbox);
 
             var selected = $element.prop('selected') || false;

--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -297,14 +297,28 @@
             checkboxName: function(option) {
                 return false; // no checkbox name
             },
+              /**
+             * Override the HTML structure on an individual list item basis. 
+             *
+             * @param {string} item
+             * @param {jQuery} element
+             */
+            templateResult: function (item, element) {
+                //console.log(item)
+                return item;
+            },
             /**
              * Create a label.
              *
              * @param {jQuery} element
              * @returns {String}
              */
-            optionLabel: function(element){
-                return $(element).attr('label') || $(element).text();
+            optionLabel: function (element) {
+                var val = $(element).attr('label') || $(element).text();
+                if (typeof this.templateResult !== "function") {
+                    throw TypeError("templateResult option should be a function.")
+                }
+                return this.templateResult(val, element);
             },
             /**
              * Create a class.

--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
 
         <link rel="stylesheet" href="dist/css/bootstrap-multiselect.css" type="text/css">
         <script type="text/javascript" src="dist/js/bootstrap-multiselect.js"></script>
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
+        
 
         <script type="text/javascript">
             $(document).ready(function() {
@@ -3286,25 +3288,81 @@ $(document).ready(function() {
                             <option value="6">Option 6</option>
                         </select>
                     </div>
+<p>The <code>templateResult</code> option will allow you to override how the list items are rendered. The function parameters are item, and a jQuery element. In order to use this, be sure to add <code>enableHTML</code></p>
+                      <div class="example">
+                        <script type="text/javascript">
+                            $(document).ready(function() {
+                                var formatItem = function (item, element) {
+                                    var $item = $(item), $el = $(element);
+
+                                    var color = "red-text";
+                                    if($el.val() % 2 === 0){
+                                        color = "green-text";
+                                    }
+                                    var $template = '<span><i class="fa fa-circle ' + color + ' fa-lg fa-fw"></i>' + $el.val() + " - <span class='red-text'>" + $el.text() + "</span></span>"
+
+                                    return $template;
+                                }
+
+                                $('#example-template-result').multiselect({
+                                    buttonContainer: '<div></div>',
+                                    buttonClass: '',
+                                    templateResult: formatItem,
+                                    enableHTML: true
+                                });
+                            });
+                        </script>
+                        <style type="text/css">
+                         
+                            .red-text{
+                                color: red !important;
+                            }
+
+                            .green-text{
+                                color: green !important;
+                            }
+                        </style>
+                        <select id="example-template-result">
+                            <option value="1">Option 1</option>
+                            <option value="2">Option 2</option>
+                            <option value="3">Option 3</option>
+                            <option value="4">Option 4</option>
+                            <option value="5">Option 5</option>
+                            <option value="6">Option 6</option>
+                        </select>
+                    </div>
                     <div class="highlight">
 <pre class="prettyprint linenums">
 &lt;script type=&quot;text/javascript&quot;&gt;
     $(document).ready(function() {
-        $('#example-filter-placeholder').multiselect({
-            buttonContainer: '&lt;div&gt;&lt;/div&gt;',
-            buttonContainer: '',
-            buttonClass: '',
-            templates: {
-                button: '&lt;span class=&quot;multiselect dropdown-toggle&quot; data-toggle=&quot;dropdown&quot;&gt;Click me!&lt;/span&gt;'
+        var formatItem = function (item, element) {
+            var $item = $(item), $el = $(element);
+
+            var color = &quot;red-text&quot;;
+            if($el.val() % 2 === 0){
+                color = &quot;green-text&quot;;
             }
+            var $template = '&lt;span&gt;&lt;i class=&quot;fa fa-circle ' + color + ' fa-lg fa-fw&quot;&gt;&lt;/i&gt;' + $el.val() + &quot; - &lt;span class='red-text'&gt;&quot; + $el.text() + &quot;&lt;/span&gt;&lt;/span&gt;&quot;
+
+            return $template;
+        }
+
+        $('#example-template-result').multiselect({
+            buttonContainer: '&lt;div&gt;&lt;/div&gt;',
+            buttonClass: '',
+            templateResult: formatItem,
+            enableHTML: true
         });
     });
 &lt;/script&gt;
 &lt;style type=&quot;text/css&quot;&gt;
-    span.multiselect {
-        padding: 2px 6px;
-        font-weight: bold;
-        cursor: pointer;
+    
+    .red-text{
+        color: red !important;
+    }
+
+    .green-text{
+        color: green !important;
     }
 &lt;/style&gt;
 </pre>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -2261,3 +2261,42 @@ describe('Knockout Binding.', function() {
         expect($testArea.next().find('button.multiselect').text().trim()).toEqual('2 selected');
     });
 });
+describe('Template result.', function () {
+    var $select;
+    beforeEach(function () {
+
+        $select = $('<select id="multiselect" multiple="multiple"></select>');
+
+        for (var i = 1; i < 100; i++) {
+            var $option = $('<option value="' + i + '">' + i + '</option>');
+
+
+            $select.append($option);
+        }
+
+        $('body').append($select);
+
+        
+
+    });
+
+    it("Should contain standard label if a custom template result is not defined", function () {
+     
+    expect($('#multiselect-container li span').length).toEqual(0)
+        
+    });
+
+    it('Should add template HTML to list item when defined', function () {
+        //  console.log($('#multiselect-container li'))
+        var formatItem = function (item, element) {
+            var $item = $(item), $el = $(element);
+            var $template = '<span>' + $el.val() + " - <span class='red-text'>" + $el.text() + "</span></span>"
+
+            return $template;
+        }
+
+        $select.multiselect({ enableHTML: true, buttonContainer: '<div id="multiselect-container"></div>', templateResult: formatItem })
+
+        expect($('#multiselect-container span.red-text').length).toBe(99)
+    });
+});


### PR DESCRIPTION
Option to override how individual list items are rendered in the dropdown. Similar to how Select2 templating works. 

When overriden the function has two parameters: item, and element. 

Added basic tests. More tests may need to be written. 
## Example usage

```
 var formatItem = function (item, element) {
    var $el = $(element);

    var color = "red-text";
    if ($el.val() % 2 === 0) {
        color = "green-text";
    }
    var $template = '<span><i class="fa fa-circle ' + color + ' fa-lg fa-fw"></i>' + $el.val() + " - <span class='red-text'>" + $el.text() + "</span></span>"

    return $template;
}

$('#example-template-result').multiselect({
    buttonContainer: '<div></div>',
    buttonClass: '',
    templateResult: formatItem,
    enableHTML: true
});
```
## Output

![bsms-ex](https://cloud.githubusercontent.com/assets/5732291/18746042/03e75f6c-80bd-11e6-911d-29926f6a8dbf.png)

Not the prettiest, I'm going to do some work on hiding the radio button with an option in another PR if I have the time. 

Apologies for the messy commits below. I made the mistake of updating my branch with master (which had other work in. 

Should now only contain the templateResult changes.
