### PR TITLE
Added option for delimiter filtering

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -430,7 +430,9 @@
                 li: '<li><a tabindex="0"><label></label></a></li>',
                 divider: '<li class="multiselect-item divider"></li>',
                 liGroup: '<li class="multiselect-item multiselect-group"><label></label></li>'
-            }
+            },
+            enableDelimiterFiltering: false,
+            filterDelimiter: ' '
         },
 
         constructor: Multiselect,
@@ -1086,6 +1088,18 @@
                                         }
                                         else if (filterCandidate.indexOf(this.query) > -1) {
                                             showElement = true;
+                                        }
+                                        else if(this.options.enableDelimiterFiltering) {
+                                            var queryArr = this.query.split(this.options.filterDelimiter);
+                                            var partialShow = true;
+                                            $(queryArr).each(function(key, value) {
+                                                if(filterCandidate.indexOf(value) === -1) {
+                                                    partialShow = false;
+                                                }
+                                            });
+                                            if(partialShow) {
+                                                showElement = true;
+                                            }
                                         }
 
                                         // Toggle current element (group or group item) according to showElement boolean.


### PR DESCRIPTION
Hey,
I needed an option to filter multiple keywords by delimiter.
For example:

**Values:** 
- Item 1 / Category 1
- Item 1 / Basket 2
- Item 1 / Test 3

Now, if I tried to search for 'item category' for example there was no result.

Now, if you enable the option **enableDelimiterFiltering** this kind of search is possible.

Additionally you can specify the delimiter for this kind of filtering by the option **filterDelimiter**.

The default is ' '.
