### PR TITLE
Fire change for clickable group

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -801,6 +801,7 @@
 
                     this.options.onChange($options, checked);
 
+                    this.$select.change();
                     this.updateButtonText();
                     this.updateSelectAll();
                 }, this));

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -655,6 +655,31 @@ describe('Bootstrap Multiselect "Clickable Optgroups"', function() {
         });
     });
 
+    it('Clickable groups should fire change only once', function() {
+        expect($('#multiselect option:selected').length).toBe(10);
+
+        var changed = 0;
+        $('#multiselect').on('change', function() {
+            changed++;
+        });
+
+        $('#multiselect-container li.multiselect-group').each(function() {
+            $('label', $(this)).click();
+
+            // Selected
+            expect(changed).toBe(1);
+            changed = 0;
+
+            $('label', $(this)).click();
+
+            // Deselected
+            expect(changed).toBe(1);
+            changed = 0;
+        });
+
+        fired = 0;
+    });
+
     it('Should update button text.', function() {
         expect($('#multiselect option:selected').length).toBe(10);
         expect(fired).toBe(0);


### PR DESCRIPTION
Hi! Thanks for the library, it's been working great. `onChange` is currently being called for clickable groups, but `change` is not being fired on the select element. This PR fixes this and adds a test for this behavior.

Fixes #799
