### PR TITLE
set value attribute also for optGroup.

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1452,7 +1452,8 @@
 
                     $tag = $('<optgroup/>').attr({
                         label: option.label || 'Group ' + groupCounter,
-                        disabled: !!option.disabled
+                        disabled: !!option.disabled,
+                        value: option.value
                     });
 
                     forEach(option.children, function(subOption) { // add children option tags


### PR DESCRIPTION
If optGroup has own value and user select optGroup you can get this value. Previously it was `undefined`.
Use case: 
I use it as a tree _Site -> Area_, each site has its own id, each area has its own id. If I select only site (it is possible) then you should be able to get `siteId` from dropdown, since site is optGroup it's not possible to get value because it end up as `undefined` in html.
