### PR TITLE
Fix for clearBtn to clear the current search query

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,8 @@
 {
-  "name": "bootstrap-multiselect",
+  "name": "bootstrap-multiselect-patch",
   "description": "Twitter Bootstrap plugin to make selects user friendly.",
-  "homepage": "http://davidstutz.github.io/bootstrap-multiselect/",
-  "version": "0.9.13",
+  "homepage": "http://github.com/marina1349/bootstrap-multiselect-patch",
+  "version": "0.9.14",
   "keywords": [
       "js",
       "css",

--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1021,6 +1021,7 @@
                             clearTimeout(this.searchTimeout);
 
                             this.$filter.find('.multiselect-search').val('');
+                            this.query = '';
                             $('li', this.$ul).show().removeClass('multiselect-filter-hidden');
 
                             this.updateSelectAll();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "bootstrap-multiselect",
-  "version": "0.9.13",
+  "name": "bootstrap-multiselect-patch",
+  "version": "0.9.14",
   "description": "JQuery multiselect plugin based on Twitter Bootstrap.",
   "main": "dist/js/bootstrap-multiselect.js",
   "directories": {
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/davidstutz/bootstrap-multiselect"
+    "url": "https://github.com/marina1349/bootstrap-multiselect-patch"
   },
   "keywords": [
     "js",


### PR DESCRIPTION
When pressing the clear button, it doesn't reset the query that was last searched. So if you search for the same query again, the filter will not be applied. This change resets the query and fixes this issue.