### PR TITLE
fixed access to properties named with javascript reserved words

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1478,9 +1478,9 @@
                         'value': option.value,
                         'label': option.label || option.value,
                         'title': option.title,
-                        'class': option.class,
-                        'selected': !!option.selected,
-                        'disabled': !!option.disabled
+                        'class': option['class'],
+                        'selected': !!option['selected'],
+                        'disabled': !!option['disabled']
                     };
                     //Loop through attributes object and add key-value for each attribute
                     for (var key in option.attributes) {


### PR DESCRIPTION
"class" is a reserved word in ECMAScript 5 and 6. yuicompressor fails with error

 java -jar "yuicompressor.jar" -v --type js "bootstrap-multiselect.js" -o "bootstrap-multiselect.min.js" --charset utf-8
[ERROR] in bootstrap-multiselect.js
  1481:46:missing name after . operator
[ERROR] in bootstrap-multiselect.js
  1482:36:syntax error
[ERROR] in bootstrap-multiselect.js
  1483:36:syntax error
[ERROR] in bootstrap-multiselect.js
  1:0:Compilation produced 3 syntax errors.
