### PR TITLE
Enhance filter performance in large lists

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1089,8 +1089,14 @@
                                         }
 
                                         // Toggle current element (group or group item) according to showElement boolean.
-                                        $(element).toggle(showElement)
-                                            .toggleClass('multiselect-filter-hidden', !showElement);
+                                        if(!showElement){
+                                          $(element).css('display', 'none');
+                                          $(element).addClass('multiselect-filter-hidden');
+                                        }
+                                        if(showElement){
+                                          $(element).css('display', 'block');
+                                          $(element).removeClass('multiselect-filter-hidden');
+                                        }
 
                                         // Differentiate groups and group items.
                                         if ($(element).hasClass('multiselect-group')) {


### PR DESCRIPTION
I ran into a performance problem when filtering large lists which caused browser hanging (specially when the page is loaded in iframe). The solution was to replace JQuery toggling by manually change the css display attr and manually add/remove classes.