### PR TITLE
Add "collapseOptGroupsByDefault" option to start opt-groups collapsed by default

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -430,7 +430,8 @@
                 li: '<li><a tabindex="0"><label></label></a></li>',
                 divider: '<li class="multiselect-item divider"></li>',
                 liGroup: '<li class="multiselect-item multiselect-group"><label></label></li>'
-            }
+            },
+            collapseOptGroupsByDefault: false
         },
 
         constructor: Multiselect,
@@ -854,7 +855,13 @@
             var $label = $('label', $li);
             $label.addClass(inputType);
             $li.addClass(classes);
-
+            
+            // Hide all children items when collapseOptGroupsByDefault is true
+            if(this.options.collapseOptGroupsByDefault && $(element).parent().prop("tagName").toLowerCase() === "optgroup") {
+              $li.addClass("multiselect-collapsible-hidden");
+              $li.hide();
+            }
+            
             if (this.options.enableHTML) {
                 $label.html(" " + label);
             }


### PR DESCRIPTION
I know there is a solution that has been provided here http://davidstutz.github.io/bootstrap-multiselect/#configuration-options-enableCollapsibleOptGroups
But, for me I had a performance issue to collapse a list of more than 4,000 items. So, I thought it might be a good idea to add an option for `collapseOptGroupsByDefault` and if it is true, hide the list items (under the opt-groups) while building the dropdown.
Feel free to advice about the option name.

Thank you