### PR TITLE
option.class uses reserved word "class" and breaks compilers

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1478,7 +1478,7 @@
                         'value': option.value,
                         'label': option.label || option.value,
                         'title': option.title,
-                        'class': option.class,
+                        'class': option['class'],
                         'selected': !!option.selected,
                         'disabled': !!option.disabled
                     };


### PR DESCRIPTION
Change option.class to option['class']

Issue: https://github.com/davidstutz/bootstrap-multiselect/issues/812