### PR TITLE
Removed `bootstrap` as a dependency.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,8 +17,7 @@
     "./dist/less/bootstrap-multiselect.less"
   ],
   "dependencies": {
-    "jquery": ">= 1.11.0",
-    "bootstrap": ">= 2.3.2"
+    "jquery": ">= 1.11.0"
   },
   "ignore": [
     "docs/.*",


### PR DESCRIPTION
`bootstrap` shouldn't be a dependency in bower.json. We use
`bootstrap-sass` and it conflicts. If you check other bootstrap plugins,
you'll find that they also don't have it. It's quite safe to say that
the majority of people that install your plugin have bootstrap already.