### PR TITLE
Fix: divider causes optGroup to become unchecked incorrectly

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1614,6 +1614,7 @@
             $groups.each(function() {
                 var $options = $(this).nextUntil('li.multiselect-group')
                     .not('.multiselect-filter-hidden')
+                    .not('.multiselect-item.divider')
                     .not('.disabled');
 
                 var checked = true;


### PR DESCRIPTION
To reproduce...

1. Create a multiselect with multiple optgroups separated by dividers. 
2. Call deselect method to deselect array of items
3. The optGroup is automatically disabled.  

Issue: 
Examine the call to updateOptGroups on line 1369. When determining checked property of each optGroup, the divider option is included in the $options collection for consideration; but it should not be.


