### PR TITLE
Use disabledText only when multiselect is disabled

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -249,9 +249,7 @@
              * @returns {String}
              */
             buttonText: function(options, select) {
-                if (this.disabledText.length > 0
-                        && (select.prop('disabled') || (options.length == 0 && this.disableIfEmpty)))  {
-
+                if (this.disabledText.length > 0 && select.prop('disabled'))  {
                     return this.disabledText;
                 }
                 else if (options.length === 0) {


### PR DESCRIPTION
Builds on https://github.com/davidstutz/bootstrap-multiselect/pull/715 to fix https://github.com/davidstutz/bootstrap-multiselect/issues/714.

Previously, the `disabledText` will display if no options are selected on the multiselect and `disableIfEmpty` is set to `true`, even if there are options present in the multiselect. The condition I removed is unnecessary because the disabled text should be displayed only when the multiselect is disabled. Whether or not any options are selected is irrelevant.