### PR TITLE
provided buttonWidth do not work

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -482,7 +482,7 @@
             // Manually add button width if set.
             if (this.options.buttonWidth && this.options.buttonWidth !== 'auto') {
                 this.$button.css({
-                    'width' : '100%', //this.options.buttonWidth,
+                    'width' : this.options.buttonWidth,
                     'overflow' : 'hidden',
                     'text-overflow' : 'ellipsis'
                 });


### PR DESCRIPTION
if options.buttonWidth is provided, the button's width will be set to  '100%', not the provided value

the correct code has been commented