### PR TITLE
Fixes an issue when calling selectAll on a filtered result

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1385,20 +1385,20 @@
             var visibleLis = $("li:not(.divider):not(.disabled):not(.multiselect-group):not(.multiselect-filter-hidden):not(.multiselect-collapisble-hidden)", this.$ul).filter(':visible');
 
             if(justVisible) {
-                $('input:enabled' , visibleLis).prop('checked', true);
+                $('input[type="checkbox"]:enabled' , visibleLis).prop('checked', true);
                 visibleLis.addClass(this.options.selectedClass);
 
-                $('input:enabled' , visibleLis).each($.proxy(function(index, element) {
+                $('input[type="checkbox"]:enabled' , visibleLis).each($.proxy(function(index, element) {
                     var value = $(element).val();
                     var option = this.getOptionByValue(value);
                     $(option).prop('selected', true);
                 }, this));
             }
             else {
-                $('input:enabled' , allLis).prop('checked', true);
+                $('input[type="checkbox"]:enabled' , allLis).prop('checked', true);
                 allLis.addClass(this.options.selectedClass);
 
-                $('input:enabled' , allLis).each($.proxy(function(index, element) {
+                $('input[type="checkbox"]:enabled' , allLis).each($.proxy(function(index, element) {
                     var value = $(element).val();
                     var option = this.getOptionByValue(value);
                     $(option).prop('selected', true);


### PR DESCRIPTION
In a dropdownlist of Contract numbers, the selectAll function on a filtered list would select all visible items plus the n th item ("n" being the filtered text). For example, if I filter on "14" and click on selectAll, I would get 114, 214, 814 and 073 (the 14th item in the list) selected.
I figured that since the deselectAll didn't have the same behavior, there was probably a small difference between them. I found it, corrected it in my project and it works properly now.