### PR TITLE
Filter by option attribute.

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -895,6 +895,11 @@
                 $checkbox.attr('name', name);
             }
 
+            // Set data for filtering.
+            if ($(element).attr('data-filtering')) {
+                $checkbox.attr('data-filtering', $(element).attr('data-filtering'));
+            }
+
             $label.prepend($checkbox);
 
             var selected = $element.prop('selected') || false;
@@ -1111,6 +1116,7 @@
                                 $.each($('li', this.$ul), $.proxy(function(index, element) {
                                     var value = $('input', element).length > 0 ? $('input', element).val() : "";
                                     var text = $('label', element).text();
+                                    var filterData = $('input', element).attr('data-filtering');
 
                                     var filterCandidate = '';
                                     if ((this.options.filterBehavior === 'text')) {
@@ -1121,6 +1127,10 @@
                                     }
                                     else if (this.options.filterBehavior === 'both') {
                                         filterCandidate = text + '\n' + value;
+                                    }
+
+                                    if (filterData) {
+                                        filterCandidate = filterCandidate + '\n' + filterData;
                                     }
 
                                     if (value !== this.options.selectAllValue && text) {


### PR DESCRIPTION
I had a case when I was need to search in selector by some value but in the same time I couldn't show those values in the selector. For example I have a list of users and my users have some similar attribute like department or every user has a unique id and I want to make search by this id but in the option or opt group I should display another information and cannot display the values which I want to user for search. I couldn't search by values also because the list was dynamically rebuild and it was hard to select values dynamically. I hope that makes sense.

I wanted to be able to define selector like this
```
   <select id="example-getting-started" multiple="multiple">
        <optgroup label="Group 1">
            <option value="cheese" data-filtering="cheese">Cheddar</option>
        </optgroup>
        <optgroup label="Group 2">
            <option value="tomatoes" data-filtering="vegetables">Tomatoes</option>
        </optgroup>
        <optgroup label="Group 2">
            <option value="mozarella" data-filtering="cheese">Mozzarella</option>
        </optgroup>
        <optgroup label="Group 3">
            <option value="mushrooms">Mushrooms</option>
        </optgroup>
        <optgroup label="Group 3">
            <option value="pepperoni">Pepperoni</option>
        </optgroup>
        <optgroup label="Group 4">
            <option value="onions" data-filtering="vegetables">Onions</option>
        </optgroup>
    </select>
```
So after that I can search values by "cheese" or "vegetables" and I don't have to add "cheese" or "vegetables" to every item (which would be look ugly). I could add those values to every "value" attribute of the options but then the method like `.val()` or `.multiselect('select', val)` would be broken (in case if I need to get unique values of objects in the list).