### PR TITLE
Fix an issue with zero value for numberDisplayed

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -257,7 +257,7 @@
                 else if (options.length === 0) {
                     return this.nonSelectedText;
                 }
-                else if (this.allSelectedText
+                else if (this.numberDisplayed == 0 || this.allSelectedText
                         && options.length === $('option', $(select)).length
                         && $('option', $(select)).length !== 1
                         && this.multiple) {


### PR DESCRIPTION
If the numberDisplayed set to zero, the functionality would not be disabled and the select element will show all of the possible options.

```
$('#multiselect-element').multiselect({
	numberDisplayed: 0
});
```