### PR TITLE
Allow customizing CollapsibleOptGroups caret icon

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -827,11 +827,13 @@
 
             if (this.options.enableCollapsibleOptGroups && this.options.multiple) {
                 $("li.multiselect-group .caret-container", this.$ul).on("click", $.proxy(function(event) {
+                    var $target = $(event.target);
                     var $li = $(event.target).closest('li');
                     var $inputs = $li.nextUntil("li.multiselect-group")
                             .not('.multiselect-filter-hidden');
 
                     var visible = true;
+                    $target.toggleClass('expanded');
                     $inputs.each(function() {
                         visible = visible && !$(this).hasClass('multiselect-collapsible-hidden');
                     });


### PR DESCRIPTION
It would be nice to have a possibility to add different CSS styles for CollapsibleOptGroups caret icon depending on whether the CollapsibleOptGroup is collapsed or expanded.
Correct me if there is another way to do it at the moment (struggled to find it - with no luck).