### PR TITLE
Optimisations on init, filtering, dropdown show/hide after profiling 20,000 options.

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1171,11 +1171,9 @@
 
                                         // Toggle current element (group or group item) according to showElement boolean.
                                         if(!showElement){
-                                          $(element).css('display', 'none');
                                           $(element).addClass('multiselect-filter-hidden');
                                         }
                                         if(showElement){
-                                          $(element).css('display', 'block');
                                           $(element).removeClass('multiselect-filter-hidden');
                                         }
 

--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1684,7 +1684,23 @@
          * @returns {jQUery}
          */
         getSelected: function() {
-            return $('option', this.$select).filter(":selected");
+            var select = this.$select[0];
+            if (select.selectedOptions !== undefined) {
+                return $(select.selectedOptions);
+            }
+
+            // selectedIndex is the index of the first option selected or -1 if nothing is selected
+            if (select.selectedIndex == -1) { 
+                return [];
+            }
+            
+            var selectedOptions = [];
+            for (var i = select.selectedIndex; i < select.length; i++) {
+                if (select.options[i].selected){
+                    selectedOptions.push(select.options[i]);
+                }
+            }
+            return $(selectedOptions);
         },
 
         /**

--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -545,33 +545,33 @@
          */
         buildDropdownOptions: function() {
 
+            var listOptions = [];
             this.$select.children().each($.proxy(function(index, element) {
-
-                var $element = $(element);
+                
                 // Support optgroups and options without a group simultaneously.
-                var tag = $element.prop('tagName')
-                    .toLowerCase();
+                var tag = element.tagName;
 
-                if ($element.prop('value') === this.options.selectAllValue) {
+                if (element.value === this.options.selectAllValue) {
                     return;
                 }
 
-                if (tag === 'optgroup') {
-                    this.createOptgroup(element);
+                if (tag === 'OPTGROUP') {
+                    listOptions.push.apply(listOptions, this.createOptgroup(element));
                 }
-                else if (tag === 'option') {
-
-                    if ($element.data('role') === 'divider') {
-                        this.createDivider();
-                    }
-                    else {
-                        this.createOptionValue(element);
-                    }
+                else if (tag === 'OPTION') {
+                    // TODO (if dividers required): Enable and add divider to listOptions 
+                    //if (element.getAttribute('data-role') === 'divider') {
+                    //    this.createDivider();
+                    //}
+                    //else {
+                        listOptions.push(this.createOptionValueString(element));
+                    //}
 
                 }
 
                 // Other illegal tags will be ignored.
             }, this));
+            this.$ul[0].innerHTML += listOptions.join('');
 
             // Bind the change event on the dropdown elements.
             $(this.$ul).off('change', 'li:not(.multiselect-group) input[type="checkbox"], li:not(.multiselect-group) input[type="radio"]');
@@ -928,6 +928,28 @@
         },
 
         /**
+         * Return an option string using the given select option.
+         *
+         * @param {jQuery} element
+         */
+        createOptionValueString: function(element) {
+            var value = element.value;
+            var title = element.text;
+            var selected = element.selected;
+            var inputType = this.options.multiple ? "checkbox" : "radio";
+             
+            var checkbox = '<input type="' + inputType + '" value="' + value + (selected ? '" checked>' : '">');
+            var label = '<label class="' + inputType + '" title="' + title + '">' + checkbox + " " + title + "</label>";
+            
+            var liClass = (selected && this.options.selectedClass ? ' class="' + this.options.selectedClass + '"' : '');
+            var li = '<li' + liClass + '><a tabindex="0">' + label + '</a></li>';
+            
+            // TODO: Implement: element.disabled check
+            
+            return li;
+        },
+
+        /**
          * Creates a divider using the given select option.
          *
          * @param {jQuery} element
@@ -969,11 +991,14 @@
                 $li.addClass('disabled');
             }
 
-            this.$ul.append($li);
+            // TODO: Optimize above
+            var optGroupOptions = [$li[0].outerHTML];
 
             $("option", group).each($.proxy(function($, group) {
-                this.createOptionValue(group);
+                optGroupOptions.push(this.createOptionValueString(group));
             }, this))
+
+            return optGroupOptions;
         },
 
         /**

--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -933,8 +933,8 @@
          * @param {jQuery} element
          */
         createOptionValueString: function(element) {
-            var value = element.value;
-            var title = element.text;
+            var value = this.escapeHtml(element.value);
+            var title = this.escapeHtml(element.text);
             var selected = element.selected;
             var inputType = this.options.multiple ? "checkbox" : "radio";
              
@@ -947,6 +947,26 @@
             // TODO: Implement: element.disabled check
             
             return li;
+        },
+
+        /**
+         * Escapes a string for use in HTML
+         *
+         * @param {String} value
+         * @returns {String}
+         */
+        escapeHtml: function(s) {
+            var ESC_MAP = {
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;'
+                };
+            
+            return s.replace(/[&<>'"]/g, function(c) {
+                return ESC_MAP[c];
+            });
         },
 
         /**

--- a/dist/less/bootstrap-multiselect.less
+++ b/dist/less/bootstrap-multiselect.less
@@ -76,9 +76,14 @@ span.multiselect-native-select select{
 
   > li {
     padding: 0;
+    overflow: hidden;
 
     > a.multiselect-all label {
       font-weight: bold;
+    }
+
+    &.multiselect-filter-hidden {
+      height: 0;
     }
 
     &.multiselect-group label {

--- a/dist/less/bootstrap-multiselect.less
+++ b/dist/less/bootstrap-multiselect.less
@@ -133,3 +133,14 @@ span.multiselect-native-select select{
     }
   }
 }
+
+.multiselect-container.dropdown-menu {
+  display: block;
+  visibility: hidden;
+  height: 0;
+}
+
+.open > .multiselect-container.dropdown-menu {
+  visibility: inherit;
+  height: auto;
+}


### PR DESCRIPTION
I profiled the plugin with 20,000 options and created the following optimisations:
(I've committed each optimisation separately for easy referencing.)

a) Optimised getSelected used in updateButtonText
The jQuery filter was causing a 16 second delay, changing it to the following removed it:
return $(this.$select.get(0).selectedOptions)
selectedOptions is supported in all major browsers except for IE (Edge supports it) so I also implemented a fall back.

b) Optimised buildDropdownOptions
This function was causing the longest delay when loading (nearly 30 seconds).
I've reduced it to under a second by building a string array and then creating the list in one shot.
I disabled dividers and the check for disabled options. You may want to develop further to support these.
Also see XSS fix.

c) Optimised dropdown show/hide
The plugin uses bootstrap drop-downs that toggles the .open style on the dropdown when the button is clicked.
Originally this toggled from display: none to display: block.
Doing so causes a reflow which can take 3 seconds to open and 15 seconds to close on 20000 options.
Toggling visibility:hidden and height:0 instead reduces the delays to about 380ms.

d) Optimised search
This was similar to c), the plugin set display:none or display:block on each list element when filtering.
I removed this and toggled height instead.
This reduced the delay from 1.4 minutes on one search to 800ms.