### PR TITLE
Required Validation Now Works on Internet Explorer

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -611,6 +611,10 @@
                 }
                 else {
                     if (checked) {
+                        // Must set selected index before making initial selection in IE
+                        if (this.$select[0].selectedIndex === -1){
+                            this.$select[0].selectedIndex = $option[0].index;
+                        }
                         $option.prop('selected', true);
 
                         if (this.options.multiple) {
@@ -636,6 +640,9 @@
                     }
                     else {
                         // Unselect option.
+                        if (this.$select.find(':selected').length  === 1){
+                            this.$select[0].selectedIndex = -1;
+                        }
                         $option.prop('selected', false);
                     }
 


### PR DESCRIPTION
Addresses the issue described in #620

The following must occur in order to pass Required Validation in Internet Explorer:

For an initial selection to be made via Jquery, the Selected Index on the Select element must first be set to a value other than -1. Once this is set, then the Selected property on the Option element may be set to true.  Note that this only occurs for the first initial selection, all subsequent selections can be made without setting the Selected Index. 

When unselecting options, the same process must occur in reverse. So when unselecting the last option, the Select element's Selected Index must be set to -1 (indicating no selections are made), then the Option element's Selected property may be set to false. This returns the Select Element to its initial state and will fail Required Validation as expected.

