### PR TITLE
rebuild now calls buildReset()

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1472,6 +1472,7 @@
             // Important to distinguish between radios and checkboxes.
             this.options.multiple = this.$select.attr('multiple') === "multiple";
 
+            this.buildReset();
             this.buildSelectAll();
             this.buildDropdownOptions();
             this.buildFilter();


### PR DESCRIPTION
'rebuild' now calls buildReset() so that includeResetOption and its associated properties are honored.

Fixes #1146 