### PR TITLE
The dataprovider method is missing arguments when it is an option group.

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1570,6 +1570,7 @@
                             value: subOption.value,
                             label: subOption.label || subOption.value,
                             title: subOption.title,
+                            class: subOption.class,
                             selected: !!subOption.selected,
                             disabled: !!subOption.disabled
                         };


### PR DESCRIPTION
The method for the dataprovider, when it is an option has the option to put a class but when it is an optiongroup we do not have that option.

It is only changed in the non-minified file, I did not find a script to minify.

Sorry if my English is not perfect.