### PR TITLE
Remove post.php

### DIFF
--- a/post.php
+++ b/post.php
@@ -1,3 +1,0 @@
-<?php
-
-print_r($_POST);


### PR DESCRIPTION
The `post.php` file has the CVE-2025-47204 but with no impact.  
It was detected by the osv-scanner.